### PR TITLE
Usage of package server to download registry for Julia 1.4 and newer.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Brown Center for Biomedical Informatics"]
-version = "1.13.5"
+version = "1.13.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/get_latest_version_from_registries.jl
+++ b/src/get_latest_version_from_registries.jl
@@ -3,48 +3,59 @@ import UUIDs
 
 function get_latest_version_from_registries!(dep_to_latest_version::Dict{Package, Union{VersionNumber, Nothing}},
                                              registry_list::Vector{Pkg.Types.RegistrySpec})
-      original_directory = pwd()
-      num_registries = length(registry_list)
-      registry_temp_dirs = Vector{String}(undef, num_registries)
-      for i = 1:num_registries
-          tmp_dir = mktempdir()
-          atexit(() -> rm(tmp_dir; force = true, recursive = true))
-          registry_temp_dirs[i] = tmp_dir
-          name = registry_list[i].name
-          url = registry_list[i].url
-          previous_directory = pwd()
-          cd(tmp_dir)
-          run(`git clone $(url) $(name)`)
-          cd(previous_directory)
-      end
-      for i = 1:num_registries
-          previous_directory = pwd()
-          registry_temp_dir = registry_temp_dirs[i]
-          name = registry_list[i].name
-          registry_path = joinpath(registry_temp_dir, name)
-          cd(registry_path)
-          registry_parsed = Pkg.TOML.parsefile(joinpath(registry_path, "Registry.toml"))
-          packages = registry_parsed["packages"]
-          for p in packages
-              name = p[2]["name"]
-              uuid = UUIDs.UUID(p[1])
-              package = Package(name, uuid)
-              path = p[2]["path"]
-              if package in keys(dep_to_latest_version)
-                  versions = VersionNumber.(collect(keys(Pkg.TOML.parsefile(joinpath(registry_path, path, "Versions.toml")))))
-                  old_value = dep_to_latest_version[package]
-                  if isnothing(old_value)
-                      dep_to_latest_version[package] = maximum(versions)
-                  else
-                      dep_to_latest_version[package] = max(old_value, maximum(versions))
-                  end
-              end
-          end
-          cd(previous_directory)
-      end
-      cd(original_directory)
-      for tmp_dir in registry_temp_dirs
-          rm(tmp_dir; force = true, recursive = true)
-      end
-      return dep_to_latest_version
+    original_directory = pwd()
+    num_registries = length(registry_list)
+    registry_temp_dirs = Vector{String}(undef, num_registries)
+    for (i, registry) enumerate(registry_list)
+        tmp_dir = mktempdir()
+        atexit(() -> rm(tmp_dir; force = true, recursive = true))
+        registry_temp_dirs[i] = tmp_dir
+        name = registry.name
+        url = registry.url
+        uuid = registry.uuid
+        registry_path = joinpath(tmp_dir, name)
+        # copied from https://github.com/JuliaLang/Pkg.jl/blob/v1.4.2/src/Types.jl#L921
+        if (url = pkg_server_registry_url(uuid)) !== nothing
+            # download from Pkg server
+            try
+                download_verify_unpack(url, nothing, registry_path, ignore_existence = true)
+            catch err
+                nothing
+            end
+        elseif reg.url !== nothing # clone from url
+            LibGit2.with(GitTools.clone(ctx, url, registry_path; header = "registry from $(repr(url))")) do repo
+            end
+        else
+            error("Could not download registry, nor pkg server not git download works.")
+        end
+    end
+    for (registry_temp_dir, registry) in zip(registry_temp_dirs, registry_list)
+        previous_directory = pwd()
+        name = registry.name
+        registry_path = joinpath(registry_temp_dir, name)
+        cd(registry_path)
+        registry_parsed = Pkg.TOML.parsefile(joinpath(registry_path, "Registry.toml"))
+        packages = registry_parsed["packages"]
+        for p in packages
+            name = p[2]["name"]
+            uuid = UUIDs.UUID(p[1])
+            package = Package(name, uuid)
+            path = p[2]["path"]
+            if package in keys(dep_to_latest_version)
+                versions = VersionNumber.(collect(keys(Pkg.TOML.parsefile(joinpath(registry_path, path, "Versions.toml")))))
+                old_value = dep_to_latest_version[package]
+                if isnothing(old_value)
+                    dep_to_latest_version[package] = maximum(versions)
+                else
+                    dep_to_latest_version[package] = max(old_value, maximum(versions))
+                end
+            end
+        end
+        cd(previous_directory)
+    end
+    cd(original_directory)
+    for tmp_dir in registry_temp_dirs
+        rm(tmp_dir; force = true, recursive = true)
+    end
+    return dep_to_latest_version
 end

--- a/src/get_latest_version_from_registries.jl
+++ b/src/get_latest_version_from_registries.jl
@@ -6,7 +6,8 @@ function get_latest_version_from_registries!(dep_to_latest_version::Dict{Package
     original_directory = pwd()
     num_registries = length(registry_list)
     registry_temp_dirs = Vector{String}(undef, num_registries)
-    for (i, registry) enumerate(registry_list)
+    registry_urls = nothing
+    for (i, registry) in enumerate(registry_list)
         tmp_dir = mktempdir()
         atexit(() -> rm(tmp_dir; force = true, recursive = true))
         registry_temp_dirs[i] = tmp_dir
@@ -14,19 +15,43 @@ function get_latest_version_from_registries!(dep_to_latest_version::Dict{Package
         url = registry.url
         uuid = registry.uuid
         registry_path = joinpath(tmp_dir, name)
-        # copied from https://github.com/JuliaLang/Pkg.jl/blob/v1.4.2/src/Types.jl#L921
-        if (url = pkg_server_registry_url(uuid)) !== nothing
-            # download from Pkg server
-            try
-                download_verify_unpack(url, nothing, registry_path, ignore_existence = true)
-            catch err
-                nothing
+        @static if VERSION >= v"1.5.0"
+            # copied from https://github.com/JuliaLang/Pkg.jl/blob/release-1.5/src/Types.jl#L981
+            reg_url, registry_urls = pkg_server_registry_url(reg.uuid, registry_urls)
+            if reg_url !== nothing
+                try
+                    Pkg.Types.download_verify_unpack(reg_url, nothing, registry_path, ignore_existence = true)
+                    @info("Downloaded registry $reg_url from package server.")
+                catch err
+                    nothing
+                end
+            elseif url !== nothing # clone from url
+                cd(tmp_dir)
+                run(`git clone $(url) $(name)`)
+                cd(previous_directory)
             end
-        elseif reg.url !== nothing # clone from url
-            LibGit2.with(GitTools.clone(ctx, url, registry_path; header = "registry from $(repr(url))")) do repo
+        elseif v"1.4.0" <= VERSION < v"1.5.0"
+            # copied from https://github.com/JuliaLang/Pkg.jl/blob/v1.4.2/src/Types.jl#L921
+            if (reg_url = Pkg.Types.pkg_server_registry_url(uuid)) !== nothing
+                # download from Pkg server
+                try
+                    Pkg.Types.download_verify_unpack(reg_url, nothing, registry_path, ignore_existence = true)
+                    @info("Downloaded registry $reg_url from package server.")
+                catch err
+                    nothing
+                end
+            elseif url !== nothing # clone from url
+                cd(tmp_dir)
+                run(`git clone $(url) $(name)`)
+                cd(previous_directory)
+            else
+                error("Could not download registry, nor pkg server not git download works.")
             end
         else
-            error("Could not download registry, nor pkg server not git download works.")
+            # original way of obtaining registry
+            cd(tmp_dir)
+            run(`git clone $(url) $(name)`)
+            cd(previous_directory)
         end
     end
     for (registry_temp_dir, registry) in zip(registry_temp_dirs, registry_list)

--- a/src/new_versions.jl
+++ b/src/new_versions.jl
@@ -317,7 +317,7 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
             run(`git add -A`)
         catch
         end
-        if hasmethod(precommit_hook, Tuple{}, (:registries,))
+        if hasmethod(precommit_hook, Tuple{AbstractString}, (:registries,))
             precommit_hook(; registries = registries)
         else
             precommit_hook()


### PR DESCRIPTION
Fixes #209 #244 
It's a bit mess but I couldn't figure out better way and it's working.
I'm able to run CompatHelper behind corporate firewall with my own registry on GitHub Enterprise with this change.