### PR TITLE
Support Julia 1.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge <dilum@aluthge.com>", "Brown Center for Biomedical Informatics"]
-version = "1.16.3"
+version = "1.16.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/get_latest_version_from_registries.jl
+++ b/src/get_latest_version_from_registries.jl
@@ -17,7 +17,7 @@ function download_or_clone(tmp_dir, previous_director, reg_url, registry_path, u
 end
 
 function get_latest_version_from_registries!(dep_to_latest_version::Dict{Package, Union{VersionNumber, Nothing}},
-                                             registry_list::Vector{Pkg.Types.RegistrySpec};
+                                             registry_list::Vector{Pkg.RegistrySpec};
                                              use_pkg_server::Bool=false)
     original_directory = pwd()
     num_registries = length(registry_list)

--- a/src/main.jl
+++ b/src/main.jl
@@ -2,14 +2,14 @@ import Pkg
 import HTTP
 import GitHub
 
-const default_registries = Pkg.Types.RegistrySpec[Pkg.RegistrySpec(name = "General",
-                                                                   uuid = "23338594-aafe-5451-b93e-139f81909106",
-                                                                   url = "https://github.com/JuliaRegistries/General.git")]
+const default_registries = Pkg.RegistrySpec[Pkg.RegistrySpec(name = "General",
+                                                             uuid = "23338594-aafe-5451-b93e-139f81909106",
+                                                             url = "https://github.com/JuliaRegistries/General.git")]
 
 function main(precommit_hook::Function = update_manifests,
               env::AbstractDict = ENV,
               ci_cfg::CIService = auto_detect_ci_service(; env = env);
-              registries::Vector{Pkg.Types.RegistrySpec} = default_registries,
+              registries::Vector{Pkg.RegistrySpec} = default_registries,
               keep_existing_compat::Bool = true,
               drop_existing_compat::Bool = false,
               bump_compat_containing_equality_specifier = true,

--- a/src/new_versions.jl
+++ b/src/new_versions.jl
@@ -20,7 +20,7 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
                                  master_branch::Union{DefaultBranch, AbstractString},
                                  subdir::AbstractString,
                                  pr_title_prefix::String,
-                                 registries::Vector{Pkg.Types.RegistrySpec})
+                                 registries::Vector{Pkg.RegistrySpec})
     original_directory = pwd()
     always_assert(keep_existing_compat || drop_existing_compat)
     for dep in keys(dep_to_current_compat_entry)
@@ -68,7 +68,7 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
                                  master_branch::Union{DefaultBranch, AbstractString},
                                  subdir::AbstractString,
                                  pr_title_prefix::String,
-                                 registries::Vector{Pkg.Types.RegistrySpec})
+                                 registries::Vector{Pkg.RegistrySpec})
     original_directory = pwd()
     always_assert(keep_existing_compat || drop_existing_compat)
     parenthetical_in_pr_title = keep_existing_compat && drop_existing_compat
@@ -223,7 +223,7 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
                                  master_branch::Union{DefaultBranch, AbstractString},
                                  subdir::AbstractString,
                                  pr_title_prefix::String,
-                                 registries::Vector{Pkg.Types.RegistrySpec})
+                                 registries::Vector{Pkg.RegistrySpec})
     original_directory = pwd()
     name = dep.name
     if subdir != ""

--- a/src/update_manifests.jl
+++ b/src/update_manifests.jl
@@ -1,5 +1,5 @@
 function update_manifests(path::AbstractString = pwd();
-                          registries::Vector{Pkg.Types.RegistrySpec} = default_registries,
+                          registries::Vector{Pkg.RegistrySpec} = default_registries,
                           delete_old_manifest::Bool = false)
     environments_to_update = Vector{String}(undef, 0)
     for (root, dirs, files) in walkdir(path)
@@ -18,7 +18,7 @@ function update_manifests(path::AbstractString = pwd();
 end
 
 function _update_manifests(environments::AbstractVector{<:AbstractString};
-                           registries::Vector{Pkg.Types.RegistrySpec},
+                           registries::Vector{Pkg.RegistrySpec},
                            delete_old_manifest::Bool)
     for environment in environments
         _update_manifest(environment;
@@ -34,7 +34,7 @@ function _has_project(environment::AbstractString)
 end
 
 function _update_manifest(environment::AbstractString;
-                          registries::Vector{Pkg.Types.RegistrySpec},
+                          registries::Vector{Pkg.RegistrySpec},
                           delete_old_manifest::Bool)
     @info("Updating environment: $(environment)")
     if _has_project(environment) && delete_old_manifest
@@ -49,14 +49,14 @@ function _update_manifest(environment::AbstractString;
         code = """
             using Pkg;
             using UUIDs;
-            Pkg.Types.RegistrySpec(name::Union{Nothing, String},
-                                   uuid::Union{Nothing, UUID},
-                                   url::Union{Nothing, String},
-                                   path::Union{Nothing, String}) = Pkg.Types.RegistrySpec(;
-                                                                                          name = name,
-                                                                                          uuid = uuid,
-                                                                                          url = url,
-                                                                                          path = path)
+            Pkg.RegistrySpec(name::Union{Nothing, String},
+                             uuid::Union{Nothing, UUID},
+                             url::Union{Nothing, String},
+                             path::Union{Nothing, String}) = Pkg.RegistrySpec(;
+                                                                              name = name,
+                                                                              uuid = uuid,
+                                                                              url = url,
+                                                                              path = path)
             registries = $(registries);
             for registry in registries;
                 Pkg.Registry.add(registry);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,16 +9,16 @@ import Printf
 import Test
 import TimeZones
 
-const registries_1 = Pkg.Types.RegistrySpec[Pkg.RegistrySpec(name = "General",
-                                                             uuid = "23338594-aafe-5451-b93e-139f81909106",
-                                                             url = "https://github.com/JuliaRegistries/General.git")]
+const registries_1 = Pkg.RegistrySpec[Pkg.RegistrySpec(name = "General",
+                                                       uuid = "23338594-aafe-5451-b93e-139f81909106",
+                                                       url = "https://github.com/JuliaRegistries/General.git")]
 
-const registries_2 = Pkg.Types.RegistrySpec[Pkg.RegistrySpec(name = "General",
-                                                             uuid = "23338594-aafe-5451-b93e-139f81909106",
-                                                             url = "https://github.com/JuliaRegistries/General.git"),
-                                            Pkg.RegistrySpec(name = "BioJuliaRegistry",
-                                                             uuid = "ccbd2cc2-2954-11e9-1ccf-f3e7900901ca",
-                                                             url = "https://github.com/BioJulia/BioJuliaRegistry.git")]
+const registries_2 = Pkg.RegistrySpec[Pkg.RegistrySpec(name = "General",
+                                                       uuid = "23338594-aafe-5451-b93e-139f81909106",
+                                                       url = "https://github.com/JuliaRegistries/General.git"),
+                                      Pkg.RegistrySpec(name = "BioJuliaRegistry",
+                                                       uuid = "ccbd2cc2-2954-11e9-1ccf-f3e7900901ca",
+                                                       url = "https://github.com/BioJulia/BioJuliaRegistry.git")]
 
 include("testutils.jl")
 


### PR DESCRIPTION
RegistrySpec moved from Pkg.Types to Pkg.Registry.
Since Pkg.RegistrySpec works on all Julia versions back to
1.2 (the earliest version supported), we don't need explicit
version checks if we use this more general way of accessing
the type.