### PR TITLE
Use `mktempdir(; cleanup = true)` instead of exit hooks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
-version = "1.18.1"
+version = "1.18.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/get_latest_version_from_registries.jl
+++ b/src/get_latest_version_from_registries.jl
@@ -50,8 +50,7 @@ function get_latest_version_from_registries!(dep_to_latest_version::Dict{Package
     registry_temp_dirs = Vector{String}(undef, num_registries)
     registry_urls = nothing
     for (i, registry) in enumerate(registry_list)
-        tmp_dir = mktempdir()
-        atexit(() -> rm(tmp_dir; force = true, recursive = true))
+        tmp_dir = mktempdir(; cleanup = true)
         registry_temp_dirs[i] = tmp_dir
         name = registry.name
         url = registry.url

--- a/src/get_project_deps.jl
+++ b/src/get_project_deps.jl
@@ -5,8 +5,7 @@ function get_project_deps(api::GitHub.GitHubAPI,
                           master_branch::Union{DefaultBranch, AbstractString},
                           subdir::AbstractString)
     original_directory = pwd()
-    tmp_dir = mktempdir()
-    atexit(() -> rm(tmp_dir; force = true, recursive = true))
+    tmp_dir = mktempdir(; cleanup = true)
     url_with_auth = "https://x-access-token:$(auth.token)@$(clone_hostname.hostname)/$(repo.full_name).git"
     cd(tmp_dir)
     try

--- a/src/new_versions.jl
+++ b/src/new_versions.jl
@@ -290,16 +290,12 @@ function make_pr_for_new_version(api::GitHub.GitHubAPI,
         url_with_auth = "https://x-access-token:$(auth.token)@$(clone_hostname.hostname)/$(repo.full_name).git"
         url_for_ssh = "git@$(clone_hostname.hostname):$(repo.full_name).git"
 
-        tmp_dir = mktempdir()
-        atexit(() -> rm(tmp_dir; force = true, recursive = true))
+        tmp_dir = mktempdir(; cleanup = true)
         cd(tmp_dir)
 
-        ssh_private_key_directory = mktempdir()
+        ssh_private_key_directory = mktempdir(; cleanup = true)
         run(`chmod 700 $(ssh_private_key_directory)`)
-        atexit(() -> rm(ssh_private_key_directory; force = true, recursive = true))
-
         ssh_private_key_filename = joinpath(ssh_private_key_directory, "privatekey")
-        atexit(() -> rm(ssh_private_key_filename; force = true, recursive = true))
 
         try
             run(`git clone $(url_with_auth) REPO`)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -23,32 +23,3 @@ function generate_pr_title_parenthetical(keep_or_drop::Symbol,
         return ""
     end
 end
-
-# Fix issues where we can't delete directories because we don't have write permissions to it.
-function prepare_for_deletion(path)
-    try
-        chmod(path, 0o755)
-    catch
-    end
-    for (root, dirs, files) in walkdir(path)
-        for dir in dirs
-            try
-                chmod(joinpath(root, dir), 0o755)
-            catch
-            end
-        end
-    end
-    return nothing
-end
-
-function with_tmp_dir(f::Function)
-    tmp_dir = mktempdir()
-    atexit() do
-        prepare_for_deletion(tmp_dir)
-        rm(tmp_dir; force = true, recursive = true)
-    end
-    result = f(tmp_dir)
-    prepare_for_deletion(tmp_dir)
-    rm(tmp_dir; force = true, recursive = true)
-    return result
-end

--- a/test/integration-test-utilities.jl
+++ b/test/integration-test-utilities.jl
@@ -103,30 +103,15 @@ function list_all_origin_branches(git_repo_dir)
 end
 
 function with_cloned_repo(f, repo_url)
-    original_working_directory = pwd()
-    result = with_temp_dir() do dir
-        git_repo_dir = joinpath(dir, "REPO")
-        cd(dir)
-        try
+    return mktempdir() do tmp_dir
+        return cd(tmp_dir) do
+            git_repo_dir = joinpath(tmp_dir, "REPO")
             run(`git clone $(repo_url) REPO`)
-        catch
+            return cd(git_repo_dir) do
+                return f(git_repo_dir)
+            end
         end
-        cd(git_repo_dir)
-        return f(git_repo_dir)
     end
-    cd(original_working_directory)
-    return result
-end
-
-function with_temp_dir(f)
-    original_working_directory = pwd()
-    tmp_dir = mktempdir()
-    atexit(() -> rm(tmp_dir; force = true, recursive = true))
-    cd(tmp_dir)
-    result = f(tmp_dir)
-    cd(original_working_directory)
-    rm(tmp_dir; force = true, recursive = true)
-    return result
 end
 
 function empty_git_repo(git_repo_dir::AbstractString)

--- a/test/unit-tests.jl
+++ b/test/unit-tests.jl
@@ -135,8 +135,8 @@ Test.@testset "get_latest_version_from_registries.jl" begin
                 name = "General"
                 url = "https://github.com/JuliaRegistries/General.git"
                 registry_urls = nothing
-                tmp_dir = mktempdir()
-                previous_directory = mktempdir()
+                tmp_dir = mktempdir(; cleanup = true)
+                previous_directory = mktempdir(; cleanup = true)
                 CompatHelper._get_registry(;
                     use_pkg_server,
                     uuid,
@@ -151,15 +151,15 @@ Test.@testset "get_latest_version_from_registries.jl" begin
     end
     Test.@testset "download_or_clone" begin
         let
-            tmp_dir = mktempdir()
-            previous_director = mktempdir()
+            tmp_dir = mktempdir(; cleanup = true)
+            previous_directory = mktempdir(; cleanup = true)
             reg_url = "https://example.com/does/not/exists"
-            registry_path = joinpath(mktempdir(), "2")
+            registry_path = joinpath(mktempdir(; cleanup = true), "2")
             url = "https://github.com/JuliaRegistries/General.git"
             name = "General"
             CompatHelper.download_or_clone(
                 tmp_dir,
-                previous_director,
+                previous_directory,
                 reg_url,
                 registry_path,
                 url,


### PR DESCRIPTION
Fixes #264 
Closes #265 