### PR TITLE
If a private key is provided, always check it (even if we don't open any new PRs)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
-version = "2.0.2"
+version = "2.0.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/main.jl
+++ b/src/main.jl
@@ -19,7 +19,7 @@ function main(env::AbstractDict = ENV,
     end
 
     if compathelper_priv_is_defined(env)
-        let
+        let _ = nothing
             _decode_ssh_private_key(env["COMPATHELPER_PRIV"])
             nothing
         end

--- a/src/main.jl
+++ b/src/main.jl
@@ -18,13 +18,15 @@ function main(env::AbstractDict = ENV,
         throw(ArgumentError("At least one of keep_existing_compat, drop_existing_compat must be true"))
     end
 
-    if compathelper_priv_is_defined(env) # we found the SSH deploy key
+    if compathelper_priv_is_defined(env)
         let
             _decode_ssh_private_key(env["COMPATHELPER_PRIV"])
             nothing
         end
+        # we found the SSH deploy key
         @info("CompatHelper found your SSH deploy key in the `COMPATHELPER_PRIV` environment variable.")
-    else # we did not find the SSH deploy key
+    else
+        # we did not find the SSH deploy key
         @info("CompatHelper did not find a valid SSH deploy key in the `COMPATHELPER_PRIV` environment variable.")
     end
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -18,8 +18,11 @@ function main(env::AbstractDict = ENV,
         throw(ArgumentError("At least one of keep_existing_compat, drop_existing_compat must be true"))
     end
 
-    COMPATHELPER_PRIV_is_defined = compathelper_priv_is_defined(env)
-    if COMPATHELPER_PRIV_is_defined # we found the SSH deploy key
+    if compathelper_priv_is_defined(env) # we found the SSH deploy key
+        let
+            _decode_ssh_private_key(env["COMPATHELPER_PRIV"])
+            nothing
+        end
         @info("CompatHelper found your SSH deploy key in the `COMPATHELPER_PRIV` environment variable.")
     else # we did not find the SSH deploy key
         @info("CompatHelper did not find a valid SSH deploy key in the `COMPATHELPER_PRIV` environment variable.")

--- a/src/ssh_keys.jl
+++ b/src/ssh_keys.jl
@@ -1,9 +1,10 @@
 @inline function _is_raw_ssh_private_key(content::AbstractString)
-    result = ( occursin("-", content) ) && ( occursin(" ", content) ) &&
-                                           ( occursin("BEGIN ", content) ) &&
-                                           ( occursin("END ", content) ) &&
-                                           ( occursin(" PRIVATE KEY", content) )
-
+    x1 = occursin("-", content)
+    x2 = occursin(" ", content)
+    x3 = occursin("BEGIN ", content)
+    x4 = occursin("END ", content)
+    x5 = occursin(" PRIVATE KEY", content)
+    result = x1 && x2 && x3 && x4 && x5
     return result
 end
 
@@ -25,8 +26,11 @@ end
 
 
 @inline function compathelper_priv_is_defined(env)
-    COMPATHELPER_PRIV_is_defined = ( haskey(env, "COMPATHELPER_PRIV") ) && ( isa(env["COMPATHELPER_PRIV"], AbstractString) ) &&
-                                                                           ( length(strip(env["COMPATHELPER_PRIV"])) > 0 ) &&
-                                                                           ( !occursin("false", strip(env["COMPATHELPER_PRIV"])) )
+    value = strip(get(env, "COMPATHELPER_PRIV", ""))
+    x1 = haskey(env, "COMPATHELPER_PRIV")
+    x2 = value isa AbstractString
+    x3 = !isempty(value)
+    x4 = value != "false"
+    result = x1 && x2 && x3 && x4
     return COMPATHELPER_PRIV_is_defined
 end

--- a/src/ssh_keys.jl
+++ b/src/ssh_keys.jl
@@ -32,5 +32,5 @@ end
     x3 = !isempty(value)
     x4 = value != "false"
     result = x1 && x2 && x3 && x4
-    return COMPATHELPER_PRIV_is_defined
+    return result
 end


### PR DESCRIPTION
Before this PR, if a private key was provided, we would only check it (e.g. try to Base64-decode it, etc.) if we needed to open a new PR.

This led to confusing behavior where some CompatHelper jobs would succeed and others would fail.

After this PR, If a private key is provided, we will always check it (even if we don't open any new PRs). Therefore, if there is a problem with your private key, all CompatHelper jobs will fail.

This should make debugging slightly easier.

cc: @ablaom