### PR TITLE
Add the `include_jll` keyword argument, which enables PRs to add/update `[compat]` entries for JLL dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
-version = "2.0.6"
+version = "2.1.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/CompatHelper.jl
+++ b/src/CompatHelper.jl
@@ -14,6 +14,7 @@ include("types.jl")
 
 include("main.jl")
 
+include("api_rate_limiting.jl")
 include("assert.jl")
 include("ci_service.jl")
 include("envdict.jl")

--- a/src/api_rate_limiting.jl
+++ b/src/api_rate_limiting.jl
@@ -1,0 +1,7 @@
+function my_retry(f::Function)
+    delays = ExponentialBackOff(;
+        n = 10,
+        max_delay = 30.0,
+    )
+    return retry(f; delays)()
+end

--- a/test/integration-test-utilities.jl
+++ b/test/integration-test-utilities.jl
@@ -146,18 +146,9 @@ function generate_branch(name::AbstractString,
             cp(src, dst; force = true)
         end
         cd(git_repo_dir)
-        try
-            run(`git add -A`)
-        catch
-        end
-        try
-            run(`git commit -m "Automatic commit - CompatHelper integration tests"`)
-        catch
-        end
-        try
-            run(`git push origin $(b)`)
-        catch
-        end
+        CompatHelper.my_retry(() -> run(`git add -A`))
+        CompatHelper.my_retry(() -> run(`git commit -m "Automatic commit - CompatHelper integration tests"`))
+        CompatHelper.my_retry(() -> run(`git push origin $(b)`))
         cd(original_working_directory)
         rm(git_repo_dir; force = true, recursive = true)
     end

--- a/test/integration-tests.jl
+++ b/test/integration-tests.jl
@@ -8,7 +8,7 @@
 COMPATHELPER_INTEGRATION_TEST_REPO = ENV["COMPATHELPER_INTEGRATION_TEST_REPO"]::String
 TEST_USER_GITHUB_TOKEN = ENV["BCBI_TEST_USER_GITHUB_TOKEN"]::String
 sleep(5)
-auth = GitHub.authenticate(TEST_USER_GITHUB_TOKEN)
+auth = CompatHelper.my_retry(() -> GitHub.authenticate(TEST_USER_GITHUB_TOKEN))
 sleep(5)
 whoami = username(auth)
 repo_url_without_auth = "https://github.com/$(COMPATHELPER_INTEGRATION_TEST_REPO)"


### PR DESCRIPTION
This PR:
- Adds the `include_jll` keyword argument, which fixes #267 
- Add some retries
- Remove some uses of `try`-`catch`

---

Once this PR is merged, you can do something like this:

```julia
CompatHelper.main(; include_jll = true)
```