### PR TITLE
Run the integration tests on both Julia v1 and Julia nightly

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -26,6 +26,7 @@ jobs:
           - ubuntu-latest
         version:
           - '1'
+          - 'nightly'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/bors.toml
+++ b/bors.toml
@@ -6,6 +6,7 @@ status = [
     "Doctests",
     "Documentation",
     "Integration/Julia 1/ubuntu-latest/x64",
+    "Integration/Julia nightly/ubuntu-latest/x64",
     "Unit/Julia 1.6.0/ubuntu-latest/x64",
     "Unit/Julia 1.6/ubuntu-latest/x64",
     "Unit/Julia 1/ubuntu-latest/x64",


### PR DESCRIPTION
The GitHub Actions virtual environments always contain the latest stable release of Julia.

Whenever a new stable version of Julia is released, the GitHub Actions staff usually update the virtual environments relatively quickly.

Therefore, we need to make sure that CompatHelper doesn't start breaking whenever the virtual environments are updated to a new version of Julia.

One step we can take is to run the integration tests on both Julia v1 and Julia nightly.