### PR TITLE
Implement fetching PullRequests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,11 +9,13 @@ Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 
 [compat]
 GitForge = "0.1"
+Mocking = "0.7"
 julia = "1.6"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "TOML"]
+test = ["Aqua", "Test", "TOML"]

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [targets]
-test = ["Test"]
+test = ["Test", "TOML"]

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ GitForge = "8f6bce27-0656-5410-875b-07a5572985df"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
 
 [compat]
+Aqua = "0.5"
 GitForge = "0.1"
 Mocking = "0.7"
 julia = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,12 @@ uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
 version = "3.0.0"
 
+[deps]
+GitForge = "8f6bce27-0656-5410-875b-07a5572985df"
+Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
+
 [compat]
+GitForge = "0.1"
 julia = "1.6"
 
 [extras]

--- a/src/CompatHelper.jl
+++ b/src/CompatHelper.jl
@@ -1,7 +1,9 @@
 module CompatHelper
 
-# TODO: delete this line. It is just here because you can't have 100% code coverage on an empty module.
-# Once we have some actual source code, we will delete this line.
-hello(x) = x + x
+using GitForge
+using GitForge: GitHub, GitLab
+using Mocking
+
+include("pull_requests.jl")
 
 end # module

--- a/src/pull_requests.jl
+++ b/src/pull_requests.jl
@@ -1,0 +1,47 @@
+for func in (:(==), :isequal)
+    @eval function Base.$func(s1::A, s2::B; kwargs...) where {A<:GitLab.MergeRequest, B<:GitLab.MergeRequest}
+        nameof(A) === nameof(B) || return false
+        fields = fieldnames(A)
+        fields === fieldnames(B) || return false
+
+        for f in fields
+            isdefined(s1, f) && isdefined(s2, f) || return false
+            $func(getfield(s1, f), getfield(s2, f); kwargs...) || return false
+        end
+
+        return true
+    end
+end
+
+function get_pull_requests(
+    api::GitHub.GitHubAPI,
+    repo::GitHub.Repo,
+    state::String;
+    per_page::Integer=100,
+    page_limit::Integer=100
+)
+    repo_name = repo.name
+    repo_owner = repo.owner.login
+    paginated_prs = GitForge.paginate(
+        GitHub.get_pull_requests, api, repo_owner, repo_name;
+        state=state, per_page=per_page, page_limit=page_limit
+    )
+
+    return @mock unique(paginated_prs)
+end
+
+function get_pull_requests(
+    api::GitLab.GitLabAPI,
+    project::GitLab.Project,
+    state::String;
+    per_page::Integer=100,
+    page::Integer=1,
+)
+    project_id = project.id
+    paginated_prs = GitForge.paginate(
+        GitLab.get_pull_requests, api, project_id;
+        state=state, per_page=per_page, page=page
+    )
+
+    return @mock unique(paginated_prs)
+end

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -1,0 +1,8 @@
+gh_unique = @patch function Base.unique(::GitForge.Paginator{GitForge.GitHub.PullRequest})
+    println("here")
+    return [GitHub.PullRequest(id=1), GitHub.PullRequest(id=2)]
+end
+
+gl_unique = @patch function Base.unique(::GitForge.Paginator{GitForge.GitLab.MergeRequest})
+    return [GitLab.MergeRequest(id=1), GitLab.MergeRequest(id=2)]
+end

--- a/test/pull_requests.jl
+++ b/test/pull_requests.jl
@@ -1,0 +1,29 @@
+@testset "GitLab.MergeRequest equality" begin
+    a = GitLab.MergeRequest(id=1)
+    b = GitLab.MergeRequest(id=1)
+
+    @test a == b
+    @test isequal(a, b)
+end
+
+@testset "get_pull_requests" begin
+    @testset "GitHub" begin
+        api = GitForge.GitHub.GitHubAPI()
+        repo = GitHub.Repo(name="Foo", owner=GitHub.User(login="Bar"))
+
+        apply(gh_unique) do
+            prs = CompatHelper.get_pull_requests(api, repo, "open"; per_page=10, page_limit=1)
+            @test !isempty(prs)
+        end
+    end
+
+    @testset "GitLab" begin
+        api = GitForge.GitLab.GitLabAPI()
+        repo = GitLab.Project(id=1)
+
+        apply(gl_unique) do
+            prs = CompatHelper.get_pull_requests(api, repo, "opened")
+            @test !isempty(prs)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Aqua
 using CompatHelper
 using GitForge
 using GitForge: GitHub, GitLab
@@ -7,6 +8,7 @@ using TOML
 
 
 Mocking.activate()
+Aqua.test_all(CompatHelper; ambiguities=false)
 
 include("patches.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,14 @@
 using CompatHelper
+using GitForge
+using GitForge: GitHub, GitLab
+using Mocking
 using Test
 
+
+Mocking.activate()
+
+include("patches.jl")
+
 @testset "CompatHelper.jl" begin
-    @test CompatHelper.hello(1) == 2 # TODO: delete this line once we have deleted the `CompatHelper.hello` function
+    include("pull_requests.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,11 +3,24 @@ using GitForge
 using GitForge: GitHub, GitLab
 using Mocking
 using Test
+using TOML
 
 
 Mocking.activate()
 
 include("patches.jl")
+
+@testset "`version =` line in the workflow file" begin
+    root_directory = dirname(dirname(@__FILE__))
+    project_file = joinpath(root_directory, "Project.toml")
+    version = Base.VersionNumber(TOML.parsefile(project_file)["version"])
+    major_version = version.major
+    @test major_version >= 1
+    workflow_dir = joinpath(root_directory, ".github", "workflows")
+    workflow_filename = joinpath(workflow_dir, "CompatHelper.yml")
+    workflow_filecontents = read(workflow_filename, String)
+    @test occursin(Regex("\\sversion = \"$(major_version)\"\n"), workflow_filecontents)
+end
 
 @testset "CompatHelper.jl" begin
     include("pull_requests.jl")


### PR DESCRIPTION
Fixes #304 

## Overview
This merge request is targeting **v3-dev**. This is a first implementation for gathering pull requests, there are a few things which need to be re-worked here, but it requires re-working the `GitForge.@pagination` functionality.

Things that we need to change and add in here:
- Ability to mock requests, currently the tests run off the basis the both the Julia and GitLab projects have merge requests in them.
- The tests do not have authenticated requests, so we can hit limitations here. I'm not sure of the best bet going forward here should be. Since we at Invenia are working on this project and taking ownership, we can create an account and some PATs as part of our efforts to keep GH Actions alive. See more on that [here](https://github.com/invenia/KeepActionsAlive).
- The pagination functionality with GitLab returns a duplicate of every PR, as a work around for now I've introduced functionality to compare `GitLab.MergeRequest` objects as it does not work currently. See https://github.com/JuliaWeb/GitForge.jl/issues/24