### PR TITLE
Project Dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,9 @@ version = "3.0.0"
 [deps]
 GitForge = "8f6bce27-0656-5410-875b-07a5572985df"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Aqua = "0.5"

--- a/src/CompatHelper.jl
+++ b/src/CompatHelper.jl
@@ -3,7 +3,11 @@ module CompatHelper
 using GitForge
 using GitForge: GitHub, GitLab
 using Mocking
+using Pkg
+using TOML
+using UUIDs
 
+include("dependencies.jl")
 include("pull_requests.jl")
 
 end # module

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -1,0 +1,101 @@
+struct Package
+    name::String
+    uuid::UUIDs.UUID
+end
+
+mutable struct CompatEntry
+    package::Package
+    version_spec::Union{Pkg.Types.VersionSpec, Nothing}
+    version_verbatim::Union{String, Nothing}
+
+    function CompatEntry(p::Package)
+        return new(p, nothing, nothing)
+    end
+end
+
+const LOCAL_REPO_NAME = "REPO"
+
+gather_stdlib_uuids() = Set{UUIDs.UUID}(x for x in keys(Pkg.Types.stdlibs()))
+git_clone(url::AbstractString, local_path::AbstractString) = run(`git clone $(url) $(local_path)`)
+git_checkout(branch::AbstractString) = run(`git checkout $(branch)`)
+
+
+"""
+    add_compat_section(project::AbstractDict)
+
+Add a k/v "compat"=>Dict{Any, Any}() if one does not exist.
+"""
+function add_compat_section!(project::AbstractDict)
+    if !haskey(project, "compat")
+        project["compat"] = Dict{Any, Any}()
+    end
+
+    return project
+end
+
+
+"""
+    get_project_deps(
+        api::GitHub.GitHubAPI, clone_hostname::AbstractString, repo::GitHub.Repo;
+        subdir::AbstractString="", include_jll::Bool=false
+    )
+
+Get a `Set{CompatEntry}` for all dependencies of `repo`.
+"""
+function get_project_deps(
+    api::GitHub.GitHubAPI, clone_hostname::AbstractString, repo::GitHub.Repo;
+    subdir::AbstractString="", include_jll::Bool=false
+)
+    mktempdir() do f
+        url_with_auth = "https://x-access-token:$(api.token)@$(clone_hostname)/$(repo.full_name).git"
+        local_path = joinpath(f, LOCAL_REPO_NAME)
+        @mock git_clone(url_with_auth, local_path)
+
+        # Get all the compat dependencies from the local Project.toml file
+        project_file = @mock joinpath(local_path, subdir, "Project.toml")
+        deps = get_project_deps(project_file; include_jll=include_jll)
+
+        return deps
+    end
+end
+
+
+"""
+    get_project_deps(project_file::AbstractString; include_jll::Bool=false)
+
+Get a Set{CompatEntry} for all dependencies in the Compat section of the project_file.
+Exclude any STDLIB packages and JLL dependencies (unless specified).
+"""
+function get_project_deps(project_file::AbstractString; include_jll::Bool=false)
+    project_deps = Set{CompatEntry}()
+    project = TOML.parsefile(project_file)
+
+    if haskey(project, "deps")
+        deps = project["deps"]
+        add_compat_section!(project)
+        compat = project["compat"]
+
+        for dep in deps
+            name = dep[1]
+            uuid = UUIDs.UUID(dep[2])
+
+            # Ignore STDLIB packages and JLL ones if flag set
+            if !Pkg.Types.is_stdlib(uuid) && (!endswith(lowercase(strip(name)), "_jll") || include_jll)
+                package = Package(name, uuid)
+                compat_entry = CompatEntry(package)
+                dep_entry = convert(String, strip(get(compat, name, "")))
+
+                if !isempty(dep_entry)
+                    compat_entry.version_spec = Pkg.Types.semver_spec(dep_entry)
+                    compat_entry.version_verbatim = dep_entry
+                end
+
+                push!(project_deps, compat_entry)
+            end
+        end
+    else
+        @info("This project has no dependencies.")
+    end
+
+    return project_deps
+end

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -15,7 +15,6 @@ end
 
 const LOCAL_REPO_NAME = "REPO"
 
-gather_stdlib_uuids() = Set{UUIDs.UUID}(x for x in keys(Pkg.Types.stdlibs()))
 git_clone(url::AbstractString, local_path::AbstractString) = run(`git clone $(url) $(local_path)`)
 git_checkout(branch::AbstractString) = run(`git checkout $(branch)`)
 

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -14,6 +14,8 @@ mutable struct CompatEntry
 end
 
 const LOCAL_REPO_NAME = "REPO"
+const GIT_COMMIT_NAME = "CompatHelper Julia"
+const GIT_COMMIT_EMAIL = "compathelper_noreply@julialang.org"
 
 git_clone(url::AbstractString, local_path::AbstractString) = run(`git clone $(url) $(local_path)`)
 git_checkout(branch::AbstractString) = run(`git checkout $(branch)`)

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -75,8 +75,6 @@ function get_project_deps(project_file::AbstractString; include_jll::Bool=false)
                 push!(project_deps, compat_entry)
             end
         end
-    else
-        @info("This project has no dependencies.")
     end
 
     return project_deps

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -20,11 +20,6 @@ git_clone(url::AbstractString, local_path::AbstractString) = run(`git clone $(ur
 git_checkout(branch::AbstractString) = run(`git checkout $(branch)`)
 
 
-"""
-    add_compat_section(project::AbstractDict)
-
-Add a k/v "compat"=>Dict{Any, Any}() if one does not exist.
-"""
 function add_compat_section!(project::AbstractDict)
     if !haskey(project, "compat")
         project["compat"] = Dict{Any, Any}()
@@ -34,14 +29,6 @@ function add_compat_section!(project::AbstractDict)
 end
 
 
-"""
-    get_project_deps(
-        api::GitHub.GitHubAPI, clone_hostname::AbstractString, repo::GitHub.Repo;
-        subdir::AbstractString="", include_jll::Bool=false
-    )
-
-Get a `Set{CompatEntry}` for all dependencies of `repo`.
-"""
 function get_project_deps(
     api::GitHub.GitHubAPI, clone_hostname::AbstractString, repo::GitHub.Repo;
     subdir::AbstractString="", include_jll::Bool=false
@@ -60,12 +47,6 @@ function get_project_deps(
 end
 
 
-"""
-    get_project_deps(project_file::AbstractString; include_jll::Bool=false)
-
-Get a Set{CompatEntry} for all dependencies in the Compat section of the project_file.
-Exclude any STDLIB packages and JLL dependencies (unless specified).
-"""
 function get_project_deps(project_file::AbstractString; include_jll::Bool=false)
     project_deps = Set{CompatEntry}()
     project = TOML.parsefile(project_file)

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -17,7 +17,7 @@ end
         # https://stackoverflow.com/a/63480330/1327636
         run(`touch foobar.txt`)
         run(`git add .`)
-        run(`git -c user.name='Foobar' -c user.email='foo@bar.org' commit -m "Message"`)
+        run(`git -c user.name='$(CompatHelper.GIT_COMMIT_NAME)' -c user.email='$(CompatHelper.GIT_COMMIT_EMAIL)' commit -m "Message"`)
         CompatHelper.git_checkout(master)
         result = String(read((`git branch --show-current`)))
 

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -1,0 +1,67 @@
+@testset "git_clone" begin
+    mktempdir() do f
+        local_path = joinpath(f, CompatHelper.LOCAL_REPO_NAME)
+        CompatHelper.git_clone("https://github.com/JuliaRegistries/CompatHelper.jl/", local_path)
+
+        @test !isempty(readdir(local_path))
+    end
+end
+
+@testset "git_branch" begin
+    master = "master"
+
+    mktempdir() do f
+        cd(f)
+        run(`git init`)
+        run(`touch foobar.txt`)
+        run(`git add .`)
+        run(`git commit -m "Foobar"`)
+        CompatHelper.git_checkout(master)
+        result = String(read((`git branch --show-current`)))
+
+        @test contains(result, master)
+    end
+end
+
+@testset "add_compat_section!" begin
+    @testset "exists" begin
+        d = Dict("compat"=>"foobar")
+        CompatHelper.add_compat_section!(d)
+
+        @test haskey(d, "compat")
+    end
+
+    @testset "dne" begin
+        d = Dict()
+        CompatHelper.add_compat_section!(d)
+
+        @test haskey(d, "compat")
+    end
+end
+
+@testset "get_project_deps" begin
+    @testset "no jll" begin
+        apply([git_clone, project_toml]) do
+            deps = CompatHelper.get_project_deps(
+                GitForge.GitHub.GitHubAPI(),
+                "",
+                GitHub.Repo(full_name="foobar"),
+            )
+
+            @test length(deps) == 1
+        end
+    end
+
+    @testset "include_jll" begin
+        apply([git_clone, project_toml]) do
+            deps = CompatHelper.get_project_deps(
+                GitForge.GitHub.GitHubAPI(),
+                "",
+                GitHub.Repo(full_name="foobar"),
+                include_jll=true
+            )
+
+            @test length(deps) == 2
+        end
+    end
+end

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -13,9 +13,11 @@ end
     mktempdir() do f
         cd(f)
         run(`git init`)
+        # Need to create a commit before hand, see below
+        # https://stackoverflow.com/a/63480330/1327636
         run(`touch foobar.txt`)
         run(`git add .`)
-        run(`git commit -m "Foobar"`)
+        run(`git -c user.name='Foobar' -c user.email='foo@bar.org' commit -m "Message"`)
         CompatHelper.git_checkout(master)
         result = String(read((`git branch --show-current`)))
 

--- a/test/deps/Project.toml
+++ b/test/deps/Project.toml
@@ -1,0 +1,13 @@
+name = "Foobar"
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "1.0.0"
+
+[deps]
+Foobar_jll = "6ca821de-e512-569d-89d9-0b16ce691416"
+Baz = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[compat]
+Foobar_jll = "1"
+Baz = "2"
+julia = "1.6"

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -6,3 +6,11 @@ end
 gl_unique = @patch function Base.unique(::GitForge.Paginator{GitForge.GitLab.MergeRequest})
     return [GitLab.MergeRequest(id=1), GitLab.MergeRequest(id=2)]
 end
+
+project_toml = @patch function Base.joinpath(p::AbstractString...)
+    return joinpath(@__DIR__, "deps", "Project.toml")
+end
+
+git_clone = @patch function CompatHelper.git_clone(url::AbstractString, p::AbstractString)
+    return nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,8 @@ include("patches.jl")
     @test occursin(Regex("\\sversion = \"$(major_version)\"\n"), workflow_filecontents)
 end
 
+
 @testset "CompatHelper.jl" begin
+    include("dependencies.jl")
     include("pull_requests.jl")
 end


### PR DESCRIPTION
Reintroducing the [get_project_dependencies.jl](https://github.com/JuliaRegistries/CompatHelper.jl/blob/a0581339bab9a49b8da58208e30dc771b9fdbb52/src/get_project_deps.jl) code back into the `v3-dev` branch.

After reading through the code it does not seem necessary to return back:

> dep_to_current_compat_entry, dep_to_current_compat_entry_verbatim, dep_to_latest_version, deps_with_missing_compat_entry

Instead I've just simplified it down to return a `Set{CompatEntry}`. The `deps_with_missing_compat_entry` was never actually used it seems? It was retrieved, passed around and when it got to [new_versions.jl](https://github.com/JuliaRegistries/CompatHelper.jl/blob/a0581339bab9a49b8da58208e30dc771b9fdbb52/src/new_versions.jl#L7) it wasn't used.