### PR TITLE
Get latest version from registries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,8 +19,9 @@ julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Test", "TOML"]
+test = ["Aqua", "Random", "Test", "TOML"]

--- a/src/CompatHelper.jl
+++ b/src/CompatHelper.jl
@@ -5,14 +5,17 @@ using GitForge
 using GitForge: GitHub, GitLab
 using Mocking
 using Pkg
+using Pkg: TOML
 using TOML
 using UUIDs
 
 const PRIVATE_SSH_ENVVAR = "COMPATHELPER_PRIV"
 
-include(joinpath("utilities", "ci.jl"))
-include(joinpath("utilities", "ssh.jl"))
 include(joinpath("utilities", "utilities.jl"))
+include(joinpath("utilities", "ci.jl"))
+include(joinpath("utilities", "git.jl"))
+include(joinpath("utilities", "ssh.jl"))
+include(joinpath("utilities", "types.jl"))
 
 include("exceptions.jl")
 include("dependencies.jl")

--- a/src/CompatHelper.jl
+++ b/src/CompatHelper.jl
@@ -6,6 +6,7 @@ using GitForge: GitHub, GitLab
 using Mocking
 using Pkg
 using Pkg: TOML
+using Pkg.Types: VersionSpec
 using TOML
 using UUIDs
 

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -31,7 +31,7 @@ function get_project_deps(
 end
 
 function get_project_deps(project_file::AbstractString; include_jll::Bool=false)
-    project_deps = Set{CompatEntry}()
+    project_deps = Set{DepInfo}()
     project = TOML.parsefile(project_file)
 
     if haskey(project, "deps")
@@ -47,7 +47,7 @@ function get_project_deps(project_file::AbstractString; include_jll::Bool=false)
             if !Pkg.Types.is_stdlib(uuid) &&
                (!endswith(lowercase(strip(name)), "_jll") || include_jll)
                 package = Package(name, uuid)
-                compat_entry = CompatEntry(package)
+                compat_entry = DepInfo(package)
                 dep_entry = convert(String, strip(get(compat, name, "")))
 
                 if !isempty(dep_entry)
@@ -81,7 +81,7 @@ function clone_all_registries(f::Function, registry_list::Vector{Pkg.RegistrySpe
 end
 
 function get_latest_version_from_registries!(
-    deps::Set{CompatEntry}, registry_list::Vector{Pkg.RegistrySpec}
+    deps::Set{DepInfo}, registry_list::Vector{Pkg.RegistrySpec}
 )
     @mock clone_all_registries(registry_list) do registry_temp_dirs
         for registry in registry_temp_dirs
@@ -104,6 +104,6 @@ function get_latest_version_from_registries!(
             end
         end
     end
-    
+
     return deps
 end

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -51,7 +51,7 @@ function get_project_deps(project_file::AbstractString; include_jll::Bool=false)
                 dep_entry = convert(String, strip(get(compat, name, "")))
 
                 if !isempty(dep_entry)
-                    compat_entry.version_number = VersionNumber(dep_entry)
+                    compat_entry.version_spec = VersionSpec(dep_entry)
                     compat_entry.version_verbatim = dep_entry
                 end
 
@@ -88,20 +88,22 @@ function get_latest_version_from_registries!(
             registry_toml_path = joinpath(registry, "Registry.toml")
             registry_toml = TOML.parsefile(joinpath(registry_toml_path))
             packages = registry_toml["packages"]
+
             for dep in deps
                 uuid = string(dep.package.uuid)
+
                 if uuid in keys(packages)
                     versions_toml_path = joinpath(
                         registry, packages[uuid]["path"], "Versions.toml"
                     )
-                    versions = VersionNumber.(
-                        collect(keys(TOML.parsefile(versions_toml_path)))
-                    )
+                    versions = VersionNumber.(collect(keys(TOML.parsefile(versions_toml_path))))
+
                     max_version = maximum(versions)
-                    dep.version_number = _max(dep.version_number, max_version)
+                    dep.latest_version = _max(dep.latest_version, max_version)
                 end
             end
         end
     end
+    
     return deps
 end

--- a/src/utilities/git.jl
+++ b/src/utilities/git.jl
@@ -1,0 +1,5 @@
+git_checkout(branch::AbstractString) = run(`git checkout $(branch)`)
+
+function git_clone(url::AbstractString, local_path::AbstractString)
+    return run(`git clone $(url) $(local_path)`)
+end

--- a/src/utilities/types.jl
+++ b/src/utilities/types.jl
@@ -5,15 +5,17 @@ end
 
 mutable struct CompatEntry
     package::Package
-    version_number::Union{VersionNumber,Nothing}
+    latest_version::Union{VersionNumber,Nothing}
+    version_spec::Union{VersionSpec,Nothing}
     version_verbatim::Union{String,Nothing}
 
     function CompatEntry(
         package::Package;
-        version_number::Union{VersionNumber,Nothing}=nothing,
+        latest_version::Union{VersionNumber,Nothing}=nothing,
+        version_spec::Union{VersionSpec,Nothing}=nothing,
         version_verbatim::Union{String,Nothing}=nothing,
     )
-        return new(package, version_number, version_verbatim)
+        return new(package, latest_version, version_spec, version_verbatim)
     end
 end
 

--- a/src/utilities/types.jl
+++ b/src/utilities/types.jl
@@ -1,0 +1,28 @@
+struct Package
+    name::String
+    uuid::UUIDs.UUID
+end
+
+mutable struct CompatEntry
+    package::Package
+    version_number::Union{VersionNumber,Nothing}
+    version_verbatim::Union{String,Nothing}
+
+    function CompatEntry(
+        package::Package;
+        version_number::Union{VersionNumber,Nothing}=nothing,
+        version_verbatim::Union{String,Nothing}=nothing,
+    )
+        return new(package, version_number, version_verbatim)
+    end
+end
+
+function Base.in(p::Package, s::Set{CompatEntry})
+    for i in s
+        if i.package == p
+            return true
+        end
+    end
+
+    return false
+end

--- a/src/utilities/types.jl
+++ b/src/utilities/types.jl
@@ -3,13 +3,13 @@ struct Package
     uuid::UUIDs.UUID
 end
 
-mutable struct CompatEntry
+mutable struct DepInfo
     package::Package
     latest_version::Union{VersionNumber,Nothing}
     version_spec::Union{VersionSpec,Nothing}
     version_verbatim::Union{String,Nothing}
 
-    function CompatEntry(
+    function DepInfo(
         package::Package;
         latest_version::Union{VersionNumber,Nothing}=nothing,
         version_spec::Union{VersionSpec,Nothing}=nothing,
@@ -19,7 +19,7 @@ mutable struct CompatEntry
     end
 end
 
-function Base.in(p::Package, s::Set{CompatEntry})
+function Base.in(p::Package, s::Set{DepInfo})
     for i in s
         if i.package == p
             return true

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -1,4 +1,13 @@
 function has_ssh_private_key(; env::AbstractDict=ENV)
     return haskey(env, PRIVATE_SSH_ENVVAR) && env[PRIVATE_SSH_ENVVAR] != "false"
 end
+
 lower(str::AbstractString) = lowercase(strip(str))
+
+function _max(x::Union{Nothing,Any}, y)
+    if x === nothing
+        return y
+    else
+        return max(x, y)
+    end
+end

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -61,17 +61,17 @@ end
     packageB = "PackageB"
     packageC = "PackageC"
 
-    deps = Set{CompatHelper.CompatEntry}([
+    deps = Set{CompatHelper.DepInfo}([
         # No version specified
-        CompatHelper.CompatEntry(CompatHelper.Package(packageA, UUID(0))),
+        CompatHelper.DepInfo(CompatHelper.Package(packageA, UUID(0))),
 
         # Version is less than what is in registry
-        CompatHelper.CompatEntry(
+        CompatHelper.DepInfo(
             CompatHelper.Package(packageB, UUID(1)); latest_version=VersionNumber(1)
         ),
 
         # Version is greater than what is in registry
-        CompatHelper.CompatEntry(
+        CompatHelper.DepInfo(
             CompatHelper.Package(packageC, UUID(2)); latest_version=VersionNumber("3")
         ),
     ])

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -67,12 +67,12 @@ end
 
         # Version is less than what is in registry
         CompatHelper.CompatEntry(
-            CompatHelper.Package(packageB, UUID(1)); version_number=VersionNumber(1)
+            CompatHelper.Package(packageB, UUID(1)); latest_version=VersionNumber(1)
         ),
 
         # Version is greater than what is in registry
         CompatHelper.CompatEntry(
-            CompatHelper.Package(packageC, UUID(2)); version_number=VersionNumber("3")
+            CompatHelper.Package(packageC, UUID(2)); latest_version=VersionNumber("3")
         ),
     ])
     apply([clone_all_registries_patch, rm_patch]) do
@@ -84,11 +84,11 @@ end
 
         for res in result
             if res.package.name == packageA
-                @test res.version_number == VersionNumber("1")
+                @test res.latest_version == VersionNumber("1")
             elseif res.package.name == packageB
-                @test res.version_number == VersionNumber("2")
+                @test res.latest_version == VersionNumber("2")
             elseif res.package.name == packageC
-                @test res.version_number == VersionNumber("3")
+                @test res.latest_version == VersionNumber("3")
             end
         end
     end

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -44,16 +44,15 @@ end
     registry_2_name = "bizbaz"
 
     apply([mktempdir_patch, git_clone_patch]) do
-        resp = CompatHelper.clone_all_registries([
+        CompatHelper.clone_all_registries([
             Pkg.RegistrySpec(; name=registry_1_name, url=""),
             Pkg.RegistrySpec(; name=registry_2_name, url=""),
-        ])
+        ]) do resp
+            @test length(resp) == 2
 
-        @test length(resp) == 2
-
-        @test contains(resp[1], registry_1_name)
-        @test contains(resp[2], registry_2_name)
-        @test length(resp) == 2
+            @test contains(resp[1], registry_1_name)
+            @test contains(resp[2], registry_2_name)
+        end
     end
 end
 

--- a/test/deps/registry_1/PackageA/Versions.toml
+++ b/test/deps/registry_1/PackageA/Versions.toml
@@ -1,0 +1,2 @@
+["1.0.0"]
+git-tree-sha1 = "b8e04c4f92d6c89dba6f1d5ace676b54186c0ac0"

--- a/test/deps/registry_1/PackageB/Versions.toml
+++ b/test/deps/registry_1/PackageB/Versions.toml
@@ -1,0 +1,5 @@
+["2.0.0"]
+git-tree-sha1 = "721a37bc5680a3906c6258d50774d9b8342178ed"
+
+["1.0.0"]
+git-tree-sha1 = "b8e04c4f92d6c89dba6f1d5ace676b54186c0ac0"

--- a/test/deps/registry_1/Registry.toml
+++ b/test/deps/registry_1/Registry.toml
@@ -1,0 +1,5 @@
+name = "Registry1"
+
+[packages]
+00000000-0000-0000-0000-000000000000 = { name = "PackageA", path = "PackageA" }
+00000000-0000-0000-0000-000000000001 = { name = "PackageB", path = "PackageB" }

--- a/test/deps/registry_2/PackageC/Versions.toml
+++ b/test/deps/registry_2/PackageC/Versions.toml
@@ -1,0 +1,2 @@
+["1.0.0"]
+git-tree-sha1 = "b8e04c4f92d6c89dba6f1d5ace676b54186c0ac0"

--- a/test/deps/registry_2/Registry.toml
+++ b/test/deps/registry_2/Registry.toml
@@ -1,0 +1,4 @@
+name = "Registry2"
+
+[packages]
+00000000-0000-0000-0000-000000000002 = { name = "PackageC", path = "PackageC" }

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -1,15 +1,28 @@
-gh_unique = @patch function Base.unique(::GitForge.Paginator{GitForge.GitHub.PullRequest})
+gh_unique_patch = @patch function Base.unique(
+    ::GitForge.Paginator{GitForge.GitHub.PullRequest}
+)
     return [GitHub.PullRequest(; id=1), GitHub.PullRequest(; id=2)]
 end
-
-gl_unique = @patch function Base.unique(::GitForge.Paginator{GitForge.GitLab.MergeRequest})
+gl_unique_patch = @patch function Base.unique(
+    ::GitForge.Paginator{GitForge.GitLab.MergeRequest}
+)
     return [GitLab.MergeRequest(; id=1), GitLab.MergeRequest(; id=2)]
 end
-
-project_toml = @patch function Base.joinpath(p::AbstractString...)
+project_toml_patch = @patch function Base.joinpath(p::AbstractString...)
     return joinpath(@__DIR__, "deps", "Project.toml")
 end
-
-git_clone = @patch function CompatHelper.git_clone(url::AbstractString, p::AbstractString)
+git_clone_patch = @patch function CompatHelper.git_clone(
+    url::AbstractString, p::AbstractString
+)
     return nothing
+end
+mktempdir_patch = @patch Base.mktempdir(; cleanup::Bool=true) = randstring()
+rm_patch = @patch Base.rm(tmp_dir; force=true, recursive=true) = nothing
+
+clone_all_registries_patch = @patch function CompatHelper.clone_all_registries(
+    registry_list::Vector{Pkg.RegistrySpec}
+)
+    return [
+        joinpath(@__DIR__, "deps", "registry_1"), joinpath(@__DIR__, "deps", "registry_2")
+    ]
 end

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -20,9 +20,10 @@ mktempdir_patch = @patch Base.mktempdir(; cleanup::Bool=true) = randstring()
 rm_patch = @patch Base.rm(tmp_dir; force=true, recursive=true) = nothing
 
 clone_all_registries_patch = @patch function CompatHelper.clone_all_registries(
+    f::Function,
     registry_list::Vector{Pkg.RegistrySpec}
 )
-    return [
+    return f([
         joinpath(@__DIR__, "deps", "registry_1"), joinpath(@__DIR__, "deps", "registry_2")
-    ]
+    ])
 end

--- a/test/pull_requests.jl
+++ b/test/pull_requests.jl
@@ -11,7 +11,7 @@ end
         api = GitForge.GitHub.GitHubAPI()
         repo = GitHub.Repo(; name="Foo", owner=GitHub.User(; login="Bar"))
 
-        apply(gh_unique) do
+        apply(gh_unique_patch) do
             prs = CompatHelper.get_pull_requests(
                 api, repo, "open"; per_page=10, page_limit=1
             )
@@ -23,7 +23,7 @@ end
         api = GitForge.GitLab.GitLabAPI()
         repo = GitLab.Project(; id=1)
 
-        apply(gl_unique) do
+        apply(gl_unique_patch) do
             prs = CompatHelper.get_pull_requests(api, repo, "opened")
             @test !isempty(prs)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,12 @@ using CompatHelper
 using GitForge
 using GitForge: GitHub, GitLab
 using Mocking
+using Pkg
+using Random
 using SHA
 using Test
 using TOML
+using UUIDs
 
 Mocking.activate()
 Aqua.test_all(CompatHelper; ambiguities=false)
@@ -27,7 +30,9 @@ include("patches.jl")
 
 @testset "CompatHelper.jl" begin
     include(joinpath("utilities", "ci.jl"))
+    include(joinpath("utilities", "git.jl"))
     include(joinpath("utilities", "ssh.jl"))
+    include(joinpath("utilities", "types.jl"))
     include(joinpath("utilities", "utilities.jl"))
 
     include("dependencies.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using GitForge
 using GitForge: GitHub, GitLab
 using Mocking
 using Pkg
+using Pkg.Types: VersionSpec
 using Random
 using SHA
 using Test

--- a/test/utilities/git.jl
+++ b/test/utilities/git.jl
@@ -1,0 +1,30 @@
+@testset "git_clone" begin
+    mktempdir() do f
+        local_path = joinpath(f, CompatHelper.LOCAL_REPO_NAME)
+        CompatHelper.git_clone(
+            "https://github.com/JuliaRegistries/CompatHelper.jl/", local_path
+        )
+
+        @test !isempty(readdir(local_path))
+    end
+end
+
+@testset "git_checkout" begin
+    master = "master"
+
+    mktempdir() do f
+        cd(f)
+        run(`git init`)
+        # Need to create a commit before hand, see below
+        # https://stackoverflow.com/a/63480330/1327636
+        run(`touch foobar.txt`)
+        run(`git add .`)
+        run(
+            `git -c user.name='$(CompatHelper.GIT_COMMIT_NAME)' -c user.email='$(CompatHelper.GIT_COMMIT_EMAIL)' commit -m "Message"`,
+        )
+        CompatHelper.git_checkout(master)
+        result = String(read((`git branch --show-current`)))
+
+        @test contains(result, master)
+    end
+end

--- a/test/utilities/types.jl
+++ b/test/utilities/types.jl
@@ -1,0 +1,14 @@
+@testset "Package Base.in" begin
+    p = CompatHelper.Package("Foobar", UUID(1))
+    ce = CompatHelper.CompatEntry(p)
+
+    @testset "Exists" begin
+        s = Set([ce])
+
+        @test p in s
+    end
+
+    @testset "DNE" begin
+        @test !(p in Set())
+    end
+end

--- a/test/utilities/types.jl
+++ b/test/utilities/types.jl
@@ -1,6 +1,6 @@
 @testset "Package Base.in" begin
     p = CompatHelper.Package("Foobar", UUID(1))
-    ce = CompatHelper.CompatEntry(p)
+    ce = CompatHelper.DepInfo(p)
 
     @testset "Exists" begin
         s = Set([ce])

--- a/test/utilities/types.jl
+++ b/test/utilities/types.jl
@@ -9,6 +9,7 @@
     end
 
     @testset "DNE" begin
-        @test !(p in Set())
+        p2 = CompatHelper.Package("BizBaz", UUID(0))
+        @test !(p2 in Set([ce]))
     end
 end


### PR DESCRIPTION
Added in the functionality for getting the latest versions from the registries, replicating the functionality from [get_latest_version_from_registries.jl](https://github.com/JuliaRegistries/CompatHelper.jl/blob/a0581339bab9a49b8da58208e30dc771b9fdbb52/src/get_latest_version_from_registries.jl) there are a few changes outlined below:

- Replace `deps_to_current_compat_entry_verbatim, dep_to_current_compat_entry, deps_with_missing_compat_entry, dep_to_latest_version` with `DepInfo`
  - All values are stored in this object, except `deps_with_missing_compat_entry` which can be inferred by the default `nothing` values.
- Moved `git` functions into their own utility file instead of being in `dependencies.jl` (more of these functions to come)
- Compared to `master` the function `get_latest_version_from_registries!` does not have the ability anymore to check the `pkg_server`, just always pull from Git instead, this just simplifies things