### PR TITLE
Fix a bug where CompatHelper opens PRs to bump to e.g. "2.0" or "2.1", instead of just "2"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/version_numbers.jl
+++ b/src/version_numbers.jl
@@ -1,50 +1,5 @@
-@inline function generate_compat_entry(v::VersionNumber)::String
-    if v.major == 0 && v.minor == 0
-        return "0.0.$(v.patch)"
-    else
-        return "$(v.major).$(v.minor)"
-    end
+function generate_compat_entry(ver::VersionNumber)
+    (ver.major > 0) && return "$(ver.major)"
+    (ver.minor > 0) && return "0.$(ver.minor)"
+    return "0.0.$(ver.patch)"
 end
-
-# The `_remove_trailing_zeros` function is based on
-# the `compat_version` function from:
-# https://github.com/invenia/PkgTemplates.jl/blob/master/src/plugins/project_file.jl
-
-@inline function _remove_trailing_zeros(v::VersionNumber)::String
-    if v.patch == 0
-        if v.minor == 0
-            if v.major == 0 # v.major is 0, v.minor is 0, v.patch is 0
-                throw(DomainError("0.0.0 is not a valid input"))
-            else # v.major is nonzero and v.minor is 0 and v.patch is 0
-                return "$(v.major)"
-            end
-        else # v.minor is nonzero, v.patch is 0
-            return "$(v.major).$(v.minor)"
-        end
-    else # v.patch is nonzero
-        return "$(v.major).$(v.minor).$(v.patch)"
-    end
-end
-
-# @inline function MajorMinorVersion(version::VersionNumber)
-#     major = version.major::Base.VInt
-#     minor = version.minor::Base.VInt
-#     result = MajorMinorVersion(major, minor)
-#     return result
-# end
-
-# @inline MajorMinorVersion(::Nothing) = nothing
-
-# @inline function VersionNumber(x::MajorMinorVersion)
-#     major = x.major::Base.VInt
-#     minor = x.minor::Base.VInt
-#     result = VersionNumber(x, y)::VersionNumber
-#     return result
-# end
-
-# @inline function Base.isless(a::MajorMinorVersion, b::MajorMinorVersion)
-#     a_versionnumber = VersionNumber(a)::VersionNumber
-#     b_versionnumber = VersionNumber(b)::VersionNumber
-#     result = Base.isless(a_versionnumber, b_versionnumber)
-#     return result
-# end

--- a/test/unit-tests.jl
+++ b/test/unit-tests.jl
@@ -115,23 +115,14 @@ Test.@testset "utils.jl" begin
 end
 
 Test.@testset "version_numbers.jl" begin
-    Test.@test CompatHelper.generate_compat_entry(v"1.2.3") == "1.2"
-    Test.@test CompatHelper.generate_compat_entry(v"1.2.0") == "1.2"
-    Test.@test CompatHelper.generate_compat_entry(v"1.0.3") == "1.0"
-    Test.@test CompatHelper.generate_compat_entry(v"1.0.0") == "1.0"
+    Test.@test CompatHelper.generate_compat_entry(v"1.2.3") == "1"
+    Test.@test CompatHelper.generate_compat_entry(v"1.2.0") == "1"
+    Test.@test CompatHelper.generate_compat_entry(v"1.0.3") == "1"
+    Test.@test CompatHelper.generate_compat_entry(v"1.0.0") == "1"
     Test.@test CompatHelper.generate_compat_entry(v"0.2.3") == "0.2"
     Test.@test CompatHelper.generate_compat_entry(v"0.2.0") == "0.2"
     Test.@test CompatHelper.generate_compat_entry(v"0.0.3") == "0.0.3"
     Test.@test CompatHelper.generate_compat_entry(v"0.0.0") == "0.0.0"
-
-    Test.@test CompatHelper._remove_trailing_zeros(v"11.22.33") == "11.22.33"
-    Test.@test CompatHelper._remove_trailing_zeros(v"11.22.0") == "11.22"
-    Test.@test CompatHelper._remove_trailing_zeros(v"11.0.33") == "11.0.33"
-    Test.@test CompatHelper._remove_trailing_zeros(v"11.0.0") == "11"
-    Test.@test CompatHelper._remove_trailing_zeros(v"0.22.33") == "0.22.33"
-    Test.@test CompatHelper._remove_trailing_zeros(v"0.22.0") == "0.22"
-    Test.@test CompatHelper._remove_trailing_zeros(v"0.0.33") == "0.0.33"
-    Test.@test_throws DomainError CompatHelper._remove_trailing_zeros(v"0.0.0")
 end
 
 Test.@testset "get_latest_version_from_registries.jl" begin


### PR DESCRIPTION
Fixes #329 