### PR TITLE
NewVersions utility functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "3.0.0"
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 GitForge = "8f6bce27-0656-5410-875b-07a5572985df"
 Mocking = "78c3b35d-d492-501b-9361-3d52fe80e533"
+MultilineStrings = "1e8d2bf6-9821-4900-9a2f-4d87552df2bd"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
@@ -14,6 +15,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 GitForge = "0.2"
+MultilineStrings = "0.1"
 Mocking = "0.7"
 julia = "1.6"
 

--- a/src/CompatHelper.jl
+++ b/src/CompatHelper.jl
@@ -2,6 +2,7 @@ module CompatHelper
 
 using Base64: Base64
 using GitForge: GitForge, GitHub, GitLab
+using MultilineStrings
 using Mocking: Mocking, @mock
 using Pkg: Pkg
 using TOML: TOML

--- a/src/CompatHelper.jl
+++ b/src/CompatHelper.jl
@@ -20,6 +20,7 @@ include(joinpath("utilities", "ci.jl"))
 include(joinpath("utilities", "git.jl"))
 include(joinpath("utilities", "ssh.jl"))
 include(joinpath("utilities", "types.jl"))
+include(joinpath("utilities", "new_versions.jl"))
 
 include("exceptions.jl")
 include("dependencies.jl")

--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -40,7 +40,7 @@ function subdir_string(subdir::AbstractString)
 end
 
 function pr_info(
-    version_verbatim::Nothing,
+    compat_entry_verbatim::Nothing,
     name::AbstractString,
     compat_entry_for_latest_version::AbstractString,
     compat_entry::AbstractString,
@@ -64,7 +64,7 @@ function pr_info(
 end
 
 function pr_info(
-    version_verbatim::AbstractString,
+    compat_entry_verbatim::AbstractString,
     name::AbstractString,
     compat_entry_for_latest_version::AbstractString,
     compat_entry::AbstractString,
@@ -78,7 +78,7 @@ function pr_info(
     """
 
     new_pr_body = m"""
-        This pull request changes the compat entry for the `$(name)` package from `$(version_verbatim)` to `$(compat_entry)` $(subdir_string). $(pr_body_keep_or_drop)
+        This pull request changes the compat entry for the `$(name)` package from `$(compat_entry_verbatim)` to `$(compat_entry)` $(subdir_string). $(pr_body_keep_or_drop)
         Note: I have not tested your package with this new compat entry.
         It is your responsibility to make sure that your package tests pass before you merge this pull request.
     """
@@ -88,14 +88,14 @@ end
 
 function skip_equality_specifiers(
     bump_compat_containing_equality_specifier::Bool,
-    version_verbatim::Union{AbstractString,Nothing},
+    compat_entry_verbatim::Union{AbstractString,Nothing},
 )
     # To check for an equality specifier (but not an inequality specifier) we look for an equals sign without any
     # symbols used for an inequality specifier that would also include an equals sign. Namely, greater than and
     # less than. Other specifiers containing symbols like ≥ shouldn't parse as containing an equals sign.
     return !bump_compat_containing_equality_specifier &&
-           !isnothing(version_verbatim) &&
-           contains(version_verbatim, '=') &&
-           !contains(version_verbatim, '>') &&
-           !contains(version_verbatim, '<')
+           !isnothing(compat_entry_verbatim) &&
+           contains(compat_entry_verbatim, '=') &&
+           !contains(compat_entry_verbatim, '>') &&
+           !contains(compat_entry_verbatim, '<')
 end

--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -1,0 +1,122 @@
+body_info(::KeepEntry, name::AbstractString) = "This keeps the compat entries for earlier versions.\n\n"
+body_info(::DropEntry, name::AbstractString) = "This drops the compat entries for earlier versions.\n\n"
+body_info(::NewEntry, name::AbstractString) = "This is a brand new compat entry. Previously, you did not have a compat entry for the `$(name)` package.\n\n"
+
+title_parenthetical(::KeepEntry) = " (keep existing compat)"
+title_parenthetical(::DropEntry) = " (drop existing compat)"
+title_parenthetical(::NewEntry) = ""
+
+function new_compat_entry(
+    ::KeepEntry,
+    old_compat::AbstractString,
+    new_compat::AbstractString,
+)
+    return "$(strip(old_compat)), $(strip(new_compat))"
+end
+
+function new_compat_entry(
+    ::Union{DropEntry, NewEntry},
+    old_compat::AbstractString,
+    new_compat::AbstractString,
+)
+    return "$(strip(new_compat))"
+end
+
+function compat_version_number(ver::VersionNumber)
+    (ver.major > 0) && return "$(ver.major)"
+    (ver.minor > 0) && return "0.$(ver.minor)"
+
+    return "0.0.$(ver.patch)"
+end
+
+function subdir_string(subdir::AbstractString)
+    if !isempty(subdir)
+        subdir_string = " for package $(splitpath(subdir)[end])"
+    else
+        subdir_string = ""
+    end
+end
+
+function pr_info(
+    version_verbatim::Nothing,
+    name::AbstractString,
+    compat_entry_for_latest_version::AbstractString,
+    compat_entry::AbstractString,
+    subdir_string::AbstractString,
+    pr_body_keep_or_drop::AbstractString,
+    pr_title_parenthetical::AbstractString,
+)
+    new_pr_title = string(
+        "CompatHelper: add new compat entry for ",
+        "\"$(name)\" at version ",
+        "\"$(compat_entry_for_latest_version)\"",
+        "$subdir_string",
+        "$(pr_title_parenthetical)"
+    )
+
+    new_pr_body = string(
+        "This pull request sets the compat ",
+        "entry for the `$(name)` package ",
+        "to `$(compat_entry)`",
+        "$subdir_string.\n\n",
+        "$(pr_body_keep_or_drop)",
+        "Note: I have not tested your package ",
+        "with this new compat entry. ",
+        "It is your responsibility to make sure that ",
+        "your package tests pass before you merge this ",
+        "pull request.\n\n",
+        "Note: Consider registering a new release of your package immediately after ",
+        "merging this PR, as downstream packages ",
+        "may depend on this for tests to pass."
+    )
+
+    return (new_pr_title, new_pr_body)
+end
+
+function pr_info(
+    version_verbatim::AbstractString,
+    name::AbstractString,
+    compat_entry_for_latest_version::AbstractString,
+    compat_entry::AbstractString,
+    subdir_string::AbstractString,
+    pr_body_keep_or_drop::AbstractString,
+    pr_title_parenthetical::AbstractString,
+)
+    new_pr_title = string(
+        "CompatHelper: bump compat for ",
+        "\"$(name)\" to ",
+        "\"$(compat_entry_for_latest_version)\"",
+        "$subdir_string",
+        "$(pr_title_parenthetical)"
+    )
+
+    new_pr_body = string(
+        "This pull request changes the compat ",
+        "entry for the `$(name)` package ",
+        "from `$(version_verbatim)` ",
+        "to `$(compat_entry)`",
+        "$subdir_string.\n\n",
+        "$(pr_body_keep_or_drop)",
+        "Note: I have not tested your package ",
+        "with this new compat entry. ",
+        "It is your responsibility to make sure that ",
+        "your package tests pass before you merge this ",
+        "pull request."
+    )
+
+    return (new_pr_title, new_pr_body)
+end
+
+function skip_equality_specifiers(
+    bump_compat_containing_equality_specifier::Bool,
+    version_verbatim::Union{AbstractString, Nothing},
+)
+# To check for an equality specifier (but not an inequality specifier) we look for an equals sign without any
+# symbols used for an inequality specifier that would also include an equals sign. Namely, greater than and
+# less than. Other specifiers containing symbols like ≥ shouldn't parse as containing an equals sign.
+    return !bump_compat_containing_equality_specifier &&
+        !isnothing(version_verbatim) &&
+        contains(version_verbatim, '=') &&
+        !contains(version_verbatim, '>') &&
+        !contains(version_verbatim, '<')
+end

--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -1,23 +1,25 @@
-body_info(::KeepEntry, name::AbstractString) = "This keeps the compat entries for earlier versions.\n\n"
-body_info(::DropEntry, name::AbstractString) = "This drops the compat entries for earlier versions.\n\n"
-body_info(::NewEntry, name::AbstractString) = "This is a brand new compat entry. Previously, you did not have a compat entry for the `$(name)` package.\n\n"
+function body_info(::KeepEntry, name::AbstractString)
+    return "This keeps the compat entries for earlier versions.\n\n"
+end
+function body_info(::DropEntry, name::AbstractString)
+    return "This drops the compat entries for earlier versions.\n\n"
+end
+function body_info(::NewEntry, name::AbstractString)
+    return "This is a brand new compat entry. Previously, you did not have a compat entry for the `$(name)` package.\n\n"
+end
 
 title_parenthetical(::KeepEntry) = " (keep existing compat)"
 title_parenthetical(::DropEntry) = " (drop existing compat)"
 title_parenthetical(::NewEntry) = ""
 
 function new_compat_entry(
-    ::KeepEntry,
-    old_compat::AbstractString,
-    new_compat::AbstractString,
+    ::KeepEntry, old_compat::AbstractString, new_compat::AbstractString
 )
     return "$(strip(old_compat)), $(strip(new_compat))"
 end
 
 function new_compat_entry(
-    ::Union{DropEntry, NewEntry},
-    old_compat::AbstractString,
-    new_compat::AbstractString,
+    ::Union{DropEntry,NewEntry}, old_compat::AbstractString, new_compat::AbstractString
 )
     return "$(strip(new_compat))"
 end
@@ -46,29 +48,17 @@ function pr_info(
     pr_body_keep_or_drop::AbstractString,
     pr_title_parenthetical::AbstractString,
 )
-    new_pr_title = string(
-        "CompatHelper: add new compat entry for ",
-        "\"$(name)\" at version ",
-        "\"$(compat_entry_for_latest_version)\"",
-        "$subdir_string",
-        "$(pr_title_parenthetical)"
-    )
+    new_pr_title = m"""
+        CompatHelper: add new compat entry for $(name) at version
+        $(compat_entry_for_latest_version) $(subdir_string), $(pr_title_parenthetical)
+    """
 
-    new_pr_body = string(
-        "This pull request sets the compat ",
-        "entry for the `$(name)` package ",
-        "to `$(compat_entry)`",
-        "$subdir_string.\n\n",
-        "$(pr_body_keep_or_drop)",
-        "Note: I have not tested your package ",
-        "with this new compat entry. ",
-        "It is your responsibility to make sure that ",
-        "your package tests pass before you merge this ",
-        "pull request.\n\n",
-        "Note: Consider registering a new release of your package immediately after ",
-        "merging this PR, as downstream packages ",
-        "may depend on this for tests to pass."
-    )
+    new_pr_body = m"""
+        This pull request sets the compat entry for the `$(name)` package to `$(compat_entry)` $(subdir_string). $(pr_body_keep_or_drop)
+        Note: I have not tested your package with this new compat entry.
+        It is your responsibility to make sure that your package tests pass before you merge this pull request.
+        Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.
+    """
 
     return (new_pr_title, new_pr_body)
 end
@@ -82,41 +72,30 @@ function pr_info(
     pr_body_keep_or_drop::AbstractString,
     pr_title_parenthetical::AbstractString,
 )
-    new_pr_title = string(
-        "CompatHelper: bump compat for ",
-        "\"$(name)\" to ",
-        "\"$(compat_entry_for_latest_version)\"",
-        "$subdir_string",
-        "$(pr_title_parenthetical)"
-    )
+    new_pr_title = m"""
+        CompatHelper: bump compat for $(name) to
+        $(compat_entry_for_latest_version) $(subdir_string), $(pr_title_parenthetical)
+    """
 
-    new_pr_body = string(
-        "This pull request changes the compat ",
-        "entry for the `$(name)` package ",
-        "from `$(version_verbatim)` ",
-        "to `$(compat_entry)`",
-        "$subdir_string.\n\n",
-        "$(pr_body_keep_or_drop)",
-        "Note: I have not tested your package ",
-        "with this new compat entry. ",
-        "It is your responsibility to make sure that ",
-        "your package tests pass before you merge this ",
-        "pull request."
-    )
+    new_pr_body = m"""
+        This pull request changes the compat entry for the `$(name)` package from `$(version_verbatim)` to `$(compat_entry)` $(subdir_string). $(pr_body_keep_or_drop)
+        Note: I have not tested your package with this new compat entry.
+        It is your responsibility to make sure that your package tests pass before you merge this pull request.
+    """
 
     return (new_pr_title, new_pr_body)
 end
 
 function skip_equality_specifiers(
     bump_compat_containing_equality_specifier::Bool,
-    version_verbatim::Union{AbstractString, Nothing},
+    version_verbatim::Union{AbstractString,Nothing},
 )
-# To check for an equality specifier (but not an inequality specifier) we look for an equals sign without any
-# symbols used for an inequality specifier that would also include an equals sign. Namely, greater than and
-# less than. Other specifiers containing symbols like ≥ shouldn't parse as containing an equals sign.
+    # To check for an equality specifier (but not an inequality specifier) we look for an equals sign without any
+    # symbols used for an inequality specifier that would also include an equals sign. Namely, greater than and
+    # less than. Other specifiers containing symbols like ≥ shouldn't parse as containing an equals sign.
     return !bump_compat_containing_equality_specifier &&
-        !isnothing(version_verbatim) &&
-        contains(version_verbatim, '=') &&
-        !contains(version_verbatim, '>') &&
-        !contains(version_verbatim, '<')
+           !isnothing(version_verbatim) &&
+           contains(version_verbatim, '=') &&
+           !contains(version_verbatim, '>') &&
+           !contains(version_verbatim, '<')
 end

--- a/src/utilities/types.jl
+++ b/src/utilities/types.jl
@@ -1,3 +1,8 @@
+abstract type EntryType end
+struct KeepEntry <: EntryType end
+struct DropEntry <: EntryType end
+struct NewEntry <: EntryType end
+
 struct Package
     name::String
     uuid::UUIDs.UUID

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ include("patches.jl")
 @testset "CompatHelper.jl" begin
     include(joinpath("utilities", "ci.jl"))
     include(joinpath("utilities", "git.jl"))
+    include(joinpath("utilities", "new_versions.jl"))
     include(joinpath("utilities", "ssh.jl"))
     include(joinpath("utilities", "types.jl"))
     include(joinpath("utilities", "utilities.jl"))

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -3,9 +3,7 @@ drop_entry = CompatHelper.DropEntry()
 new_entry = CompatHelper.NewEntry()
 
 @testset "body_info -- $(entry)" for (entry, expected) in [
-    (keep_entry, "keeps"),
-    (drop_entry, "drops"),
-    (new_entry, " brand new")
+    (keep_entry, "keeps"), (drop_entry, "drops"), (new_entry, " brand new")
 ]
     name = "foobar"
     result = CompatHelper.body_info(entry, name)
@@ -17,9 +15,7 @@ new_entry = CompatHelper.NewEntry()
 end
 
 @testset "title_parenthetical -- $(entry)" for (entry, expected) in [
-    (keep_entry, "keep"),
-    (drop_entry, "drop"),
-    (new_entry, "")
+    (keep_entry, "keep"), (drop_entry, "drop"), (new_entry, "")
 ]
     result = CompatHelper.title_parenthetical(entry)
 
@@ -36,20 +32,20 @@ end
             (" old ", " new ", "old, new"),
             ("old", "new", "old, new"),
             ("Old", "New", "Old, New"),
-            ("OLD", "NEW", "OLD, NEW")
+            ("OLD", "NEW", "OLD, NEW"),
         ],
         drop_entry => [
             (" old ", " new ", "new"),
             ("old", "new", "new"),
             ("Old", "New", "New"),
-            ("OLD", "NEW", "NEW")
+            ("OLD", "NEW", "NEW"),
         ],
         new_entry => [
             (" old ", " new ", "new"),
             ("old", "new", "new"),
             ("Old", "New", "New"),
-            ("OLD", "NEW", "NEW")
-        ]
+            ("OLD", "NEW", "NEW"),
+        ],
     )
 
     entries = collect(keys(cases))
@@ -71,16 +67,13 @@ end
     (VersionNumber("0.1.0"), "0.1"),
     (VersionNumber("0.1.1"), "0.1"),
     (VersionNumber("0.0.1"), "0.0.1"),
-    (VersionNumber("0.0.0"), "0.0.0")
+    (VersionNumber("0.0.0"), "0.0.0"),
 ]
     @test CompatHelper.compat_version_number(vn) == expected
 end
 
 @testset "subdir_string -- $(subdir)" for (subdir, expected) in [
-    ("foobar", "foobar"),
-    ("foo/bar", "bar"),
-    ("1", "1"),
-    ("", ""),
+    ("foobar", "foobar"), ("foo/bar", "bar"), ("1", "1"), ("", "")
 ]
     if !isempty(subdir)
         @test contains(CompatHelper.subdir_string(subdir), expected)
@@ -112,7 +105,7 @@ end
     ("", "bump compat for", "pull request changes the compat")
 ]
     verbatim, expected_title, expected_body = case
-    title, body = CompatHelper.pr_info(verbatim, "", "", "", "", "", "",)
+    title, body = CompatHelper.pr_info(verbatim, "", "", "", "", "", "")
 
     @test contains(title, expected_title)
     @test contains(body, expected_body)

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -1,0 +1,122 @@
+keep_entry = CompatHelper.KeepEntry()
+drop_entry = CompatHelper.DropEntry()
+new_entry = CompatHelper.NewEntry()
+
+@testset "body_info -- $(entry)" for (entry, expected) in [
+    (keep_entry, "keeps"),
+    (drop_entry, "drops"),
+    (new_entry, " brand new")
+]
+    name = "foobar"
+    result = CompatHelper.body_info(entry, name)
+    @test contains(result, expected)
+
+    if entry isa CompatHelper.NewEntry
+        @test contains(result, name)
+    end
+end
+
+@testset "title_parenthetical -- $(entry)" for (entry, expected) in [
+    (keep_entry, "keep"),
+    (drop_entry, "drop"),
+    (new_entry, "")
+]
+    result = CompatHelper.title_parenthetical(entry)
+
+    if !(entry isa CompatHelper.NewEntry)
+        @test contains(result, expected)
+    else
+        @test isempty(result)
+    end
+end
+
+@testset "new_compat_entry" begin
+    cases = Dict(
+        keep_entry => [
+            (" old ", " new ", "old, new"),
+            ("old", "new", "old, new"),
+            ("Old", "New", "Old, New"),
+            ("OLD", "NEW", "OLD, NEW")
+        ],
+        drop_entry => [
+            (" old ", " new ", "new"),
+            ("old", "new", "new"),
+            ("Old", "New", "New"),
+            ("OLD", "NEW", "NEW")
+        ],
+        new_entry => [
+            (" old ", " new ", "new"),
+            ("old", "new", "new"),
+            ("Old", "New", "New"),
+            ("OLD", "NEW", "NEW")
+        ]
+    )
+
+    entries = collect(keys(cases))
+
+    @testset "$(entry)" for entry in entries
+        for case in cases[entry]
+            old_compat, new_compat, expected = case
+            result = CompatHelper.new_compat_entry(entry, old_compat, new_compat)
+
+            @test result == expected
+        end
+    end
+end
+
+@testset "compat_version_number -- $(vn)" for (vn, expected) in [
+    (VersionNumber("1.0.0"), "1"),
+    (VersionNumber("1.1.1"), "1"),
+    (VersionNumber("1.1.1"), "1"),
+    (VersionNumber("0.1.0"), "0.1"),
+    (VersionNumber("0.1.1"), "0.1"),
+    (VersionNumber("0.0.1"), "0.0.1"),
+    (VersionNumber("0.0.0"), "0.0.0")
+]
+    @test CompatHelper.compat_version_number(vn) == expected
+end
+
+@testset "subdir_string -- $(subdir)" for (subdir, expected) in [
+    ("foobar", "foobar"),
+    ("foo/bar", "bar"),
+    ("1", "1"),
+    ("", ""),
+]
+    if !isempty(subdir)
+        @test contains(CompatHelper.subdir_string(subdir), expected)
+    else
+        @test CompatHelper.subdir_string(subdir) === ""
+    end
+end
+
+@testset "skip_equality_specifiers" begin
+    cases = [
+        (false, "=", true)
+        (false, ">=", false)
+        (false, "<=", false)
+        (false, ">", false)
+        (false, "<", false)
+    ]
+
+    for case in cases
+        bump_specifier, verbatim, expected = case
+        @test CompatHelper.skip_equality_specifiers(bump_specifier, verbatim) == expected
+    end
+
+    # If bump_compat_containing_equality_specifier is set to true, always return back false
+    for case in cases
+        bump_specifier, verbatim, expected = case
+        @test CompatHelper.skip_equality_specifiers(!bump_specifier, verbatim) == false
+    end
+end
+
+@testset "pr_info -- $(typeof(case[1]))" for case in [
+    (nothing, "add new compat entry for", "pull request sets the compat")
+    ("", "bump compat for", "pull request changes the compat")
+]
+    verbatim, expected_title, expected_body = case
+    title, body = CompatHelper.pr_info(verbatim, "", "", "", "", "", "",)
+
+    @test contains(title, expected_title)
+    @test contains(body, expected_body)
+end

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -67,7 +67,7 @@ end
 @testset "compat_version_number -- $(vn)" for (vn, expected) in [
     (VersionNumber("1.0.0"), "1"),
     (VersionNumber("1.1.1"), "1"),
-    (VersionNumber("1.1.1"), "1"),
+    (VersionNumber("1.1.0"), "1"),
     (VersionNumber("0.1.0"), "0.1"),
     (VersionNumber("0.1.1"), "0.1"),
     (VersionNumber("0.0.1"), "0.0.1"),
@@ -101,11 +101,8 @@ end
     for case in cases
         bump_specifier, verbatim, expected = case
         @test CompatHelper.skip_equality_specifiers(bump_specifier, verbatim) == expected
-    end
 
-    # If bump_compat_containing_equality_specifier is set to true, always return back false
-    for case in cases
-        bump_specifier, verbatim, expected = case
+        # If bump_compat_containing_equality_specifier is set to true, always return back false
         @test CompatHelper.skip_equality_specifiers(!bump_specifier, verbatim) == false
     end
 end


### PR DESCRIPTION
I was originally going to re-write the [new_versions.jl](https://github.com/JuliaRegistries/CompatHelper.jl/blob/0afb9df0164b9389ffbd444978b7e9c2e61fa5b3/src/new_versions.jl) file, but realized there are too many smaller functions and it would become an eye-sore to read through.

Instead, here's a smaller PR for some utility functions that will be used in a future PR.