### PR TITLE
Bump Version of Package

### DIFF
--- a/src/main.jl
+++ b/src/main.jl
@@ -18,6 +18,7 @@ function main(
     include_jll::Bool=false,
     unsub_from_prs=false,
     cc_user=false,
+    bump_version=false,
 )
     api, repo = get_api_and_repo(ci_cfg, hostname_for_api)
 
@@ -42,6 +43,7 @@ function main(
                 pr_title_prefix=pr_title_prefix,
                 unsub_from_prs=unsub_from_prs,
                 cc_user=cc_user,
+                bump_version=bump_version,
             )
         end
     end

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -245,7 +245,7 @@ end
     end
 end
 
-@testset "add_compat_entry" begin
+@testset "modify_project_toml" begin
     mktempdir() do tmpdir
         # Lets copy our test Project.toml to the tmpdir for this test
         src = joinpath(@__DIR__, "..", "deps", "Project.toml")
@@ -255,7 +255,7 @@ end
         project = TOML.parsefile(dst)
         @test !haskey(project["compat"], "PackageA")
 
-        CompatHelper.add_compat_entry("PackageA", tmpdir, "= 1.2")
+        CompatHelper.modify_project_toml("PackageA", tmpdir, "= 1.2", false)
 
         project = TOML.parsefile(dst)
         @test project["compat"]["PackageA"] == "= 1.2"

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -262,6 +262,32 @@ end
     end
 end
 
+@testset "bump_package_version" begin
+    @testset "minor bump" begin
+        mock_toml = Dict("version" => "1.4.5")
+
+        @test mock_toml["version"] == "1.4.5"
+        CompatHelper.bump_package_version!(mock_toml)
+        @test mock_toml["version"] == "1.5.0"
+    end
+
+    @testset "patch bump" begin
+        mock_toml = Dict("version" => "0.5.2")
+
+        @test mock_toml["version"] == "0.5.2"
+        CompatHelper.bump_package_version!(mock_toml)
+        @test mock_toml["version"] == "0.5.3"
+    end
+
+    @testset "dev prerelease" begin
+        mock_toml = Dict("version" => "1.2.3-DEV")
+
+        @test mock_toml["version"] == "1.2.3-DEV"
+        CompatHelper.bump_package_version!(mock_toml)
+        @test mock_toml["version"] == "1.2.3-DEV"
+    end
+end
+
 @testset "cc_mention_user" begin
     @testset "GitHub" begin
         apply(gh_comment_patch) do


### PR DESCRIPTION
It seems typical to bump the package version when adding dependency compat values. I have set this to false by default but if we want it true by default I can change it.

If the package is >= 1.0 then the minor value will be bumped and the patch will go to 0. If the package is < 1.0 then only the patch value will be bumped.

I had a request to ignore the bumping of version values if a pre-release strings exists in the version number such as `-DEV`. Let me know if this needs to be relaxed or if we want a different rule for it.

Note: This was made against the v3-dev branch. 

closes #132 