### PR TITLE
Main Returns the PRs that it creates

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,7 +18,7 @@ makedocs(;
         "Configuration Options" => "options.md",
         "Acknowledgements" => "acknowledgements.md",
         "Other Environments" => "other-environments.md",
-        "TroubleShooting" => "troubleshooting.md"
+        "TroubleShooting" => "troubleshooting.md",
     ],
     strict=true,
 )

--- a/src/utilities/ci.jl
+++ b/src/utilities/ci.jl
@@ -10,7 +10,7 @@ struct GitHubActions <: CIService
         username="github-actions[bot]",
         email="41898282+github-actions[bot]@users.noreply.github.com",
         api_hostname="https://api.github.com",
-        clone_hostname="github.com"
+        clone_hostname="github.com",
     )
         return new(username, email, api_hostname, clone_hostname)
     end
@@ -26,7 +26,7 @@ struct GitLabCI <: CIService
         username="gitlab-ci[bot]",
         email="gitlab-ci[bot]@gitlab.com",
         api_hostname="https://gitlab.com/api/v4",
-        clone_hostname="gitlab.com"
+        clone_hostname="gitlab.com",
     )
         return new(username, email, api_hostname, clone_hostname)
     end

--- a/src/utilities/git.jl
+++ b/src/utilities/git.jl
@@ -70,7 +70,7 @@ function git_clone(
     withenv(
         "GIT_SSH_COMMAND" => isnothing(pkey_filename) ? "ssh" : "ssh -i $pkey_filename"
     ) do
-        @mock run(`git clone $url $local_path`)
+        run(`git clone $url $local_path`)
     end
 
     return nothing

--- a/src/utilities/git.jl
+++ b/src/utilities/git.jl
@@ -70,7 +70,7 @@ function git_clone(
     withenv(
         "GIT_SSH_COMMAND" => isnothing(pkey_filename) ? "ssh" : "ssh -i $pkey_filename"
     ) do
-        run(`git clone $url $local_path`)
+        @mock run(`git clone $url $local_path`)
     end
 
     return nothing

--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -148,9 +148,7 @@ function create_new_pull_request(
     )
 end
 
-function get_url_with_auth(
-    api::GitHub.GitHubAPI, ci::GitHubActions, repo::GitHub.Repo
-)
+function get_url_with_auth(api::GitHub.GitHubAPI, ci::GitHubActions, repo::GitHub.Repo)
     return "https://x-access-token:$(api.token.token)@$(ci.clone_hostname)/$(repo.full_name).git"
 end
 
@@ -158,9 +156,7 @@ function get_url_for_ssh(::GitHub.GitHubAPI, ci::GitHubActions, repo::GitHub.Rep
     return "git@$(ci.clone_hostname):$(repo.full_name).git"
 end
 
-function get_url_with_auth(
-    api::GitLab.GitLabAPI, ci::GitLabCI, repo::GitLab.Project
-)
+function get_url_with_auth(api::GitLab.GitLabAPI, ci::GitLabCI, repo::GitLab.Project)
     return "https://oauth2:$(api.token.token)@$(ci.clone_hostname)/$(repo.path_with_namespace).git"
 end
 
@@ -386,7 +382,7 @@ function bump_package_version!(project::Dict)
             version.minor,
             version.patch + 1,
             version.prerelease,
-            version.build
+            version.build,
         )
     end
 

--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -247,6 +247,7 @@ function make_pr_for_new_version(
     end
 
     # Make a dir for our SSH PrivateKey which we will use only if it has been enabled
+    created_pr = nothing
     with_temp_dir(; cleanup=true) do ssh_private_key_dir
         ssh_envvar = has_ssh_private_key(; env=env)
 
@@ -306,11 +307,13 @@ function make_pr_for_new_version(
 
                 cc_user && cc_mention_user(forge, repo, new_pr; env=env)
                 unsub_from_prs && unsub_from_pr(forge, new_pr)
+
+                created_pr = new_pr
             end
         end
     end
 
-    return nothing
+    return created_pr
 end
 
 function cc_mention_user(

--- a/test/deps/Project.toml
+++ b/test/deps/Project.toml
@@ -9,5 +9,5 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 Foobar_jll = "1"
-Baz = "2"
+Baz = "1"
 julia = "1.6"

--- a/test/main.jl
+++ b/test/main.jl
@@ -69,8 +69,6 @@
         end
     end
 
-
-
     @testset "successful run GitLab" begin
         mktempdir() do tmpdir
             cd(tmpdir) do

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -155,3 +155,10 @@ gl_make_pr_patch = @patch function CompatHelper.make_pr_for_new_version(
 )
     return GitLab.MergeRequest()
 end
+
+function make_ssh_clone_patch(dir)
+    return @patch function Base.run(cmd)
+        mkdir(dir)
+        return run(`touch $dir/foo.txt`)
+    end
+end

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -143,3 +143,15 @@ gl_unsub_patch = @patch function GitForge.unsubscribe_from_pull_request(
 )
     return GitLab.MergeRequest(), nothing
 end
+
+gh_make_pr_patch = @patch function CompatHelper.make_pr_for_new_version(
+    ::GitHub.GitHubAPI, ::GitHub.Repo, ::DepInfo, ::EntryType, ::CIService; kwargs...
+)
+    return GitHub.PullRequest()
+end
+
+gl_make_pr_patch = @patch function CompatHelper.make_pr_for_new_version(
+    ::GitLab.GitLabAPI, ::GitLab.Project, ::DepInfo, ::EntryType, ::CIService; kwargs...
+)
+    return GitLab.MergeRequest()
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Aqua
 using Base64
 using CompatHelper
+using CompatHelper: DepInfo, EntryType
 using Dates
 using GitForge
 using GitForge: GitForge, GitHub, GitLab

--- a/test/utilities/git.jl
+++ b/test/utilities/git.jl
@@ -243,13 +243,6 @@ end
     end
 end
 
-function make_ssh_clone_patch(dir)
-    return @patch function Base.run(cmd)
-        mkdir(dir)
-        return run(`touch $dir/foo.txt`)
-    end
-end
-
 @testset "git_clone" begin
     @testset "HTTPS" begin
         mktempdir() do f

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -406,7 +406,7 @@ end
                         delete!(ENV, CompatHelper.PRIVATE_SSH_ENVVAR)
                     end
 
-                    CompatHelper.make_pr_for_new_version(
+                    pr = CompatHelper.make_pr_for_new_version(
                         GitHub.GitHubAPI(; token=GitHub.Token("token")),
                         GitHub.Repo(;
                             owner=GitHub.User(; login="username"), name="PackageB"
@@ -419,10 +419,11 @@ end
                         CompatHelper.KeepEntry(),
                         CompatHelper.GitHubActions(),
                     )
+                    @test pr isa GitHub.PullRequest
 
                     # SSH
                     withenv(CompatHelper.PRIVATE_SSH_ENVVAR => "foo") do
-                        CompatHelper.make_pr_for_new_version(
+                        pr = CompatHelper.make_pr_for_new_version(
                             GitHub.GitHubAPI(; token=GitHub.Token("token")),
                             GitHub.Repo(;
                                 owner=GitHub.User(; login="username"), name="PackageC"
@@ -435,6 +436,7 @@ end
                             CompatHelper.KeepEntry(),
                             CompatHelper.GitHubActions(),
                         )
+                        @test pr isa GitHub.PullRequest
                     end
                 end
             end

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -189,9 +189,7 @@ end
 
     @testset "GitLab" begin
         result = CompatHelper.get_url_for_ssh(
-            GitLab.GitLabAPI(),
-            gitlab,
-            GitLab.Project(; path_with_namespace="full_name"),
+            GitLab.GitLabAPI(), gitlab, GitLab.Project(; path_with_namespace="full_name")
         )
 
         @test result == "git@hostname:full_name.git"


### PR DESCRIPTION
In some situations it would seem useful to do post processing after CompatHelper runs based on the PRs that were created during the run. I propose we just return a vector of PRs 