### PR TITLE
create_pull_request should use id for GitLab

### DIFF
--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -114,13 +114,9 @@ function create_new_pull_request(
     title::AbstractString,
     body::AbstractString,
 )
-    repo_owner = String(rsplit(repo.path_with_namespace, "/"; limit=2)[1])
-
     return @mock GitForge.create_pull_request(
         api,
-        repo_owner,
-        repo.name;
-        id=repo.id,
+        repo.id;
         source_branch=new_branch_name,
         target_branch=master_branch_name,
         title=title,

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -42,7 +42,7 @@ gh_pr_patch = @patch function GitForge.create_pull_request(
 end
 
 gl_pr_patch = @patch function GitForge.create_pull_request(
-    ::GitLab.GitLabAPI, owner::AbstractString, repo::AbstractString; kwargs...
+    ::GitLab.GitLabAPI, id::Integer; kwargs...
 )
     return GitLab.MergeRequest(), nothing
 end

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -139,11 +139,7 @@ end
         apply(gl_pr_patch) do
             result, n = CompatHelper.create_new_pull_request(
                 GitLab.GitLabAPI(),
-                GitLab.Project(;
-                    owner=GitLab.User(; name="username"),
-                    name="repo",
-                    path_with_namespace="owner/repo",
-                ),
+                GitLab.Project(; id=1),
                 "new_branch",
                 "master_brach",
                 "title",


### PR DESCRIPTION
Looks like using owner/repo doesn't work well for projects in subgroups such as "group/subgroup/repo.jl", using just the numerical id instead is a better solution anyway. 