### PR TITLE
Add flag for a short branch name

### DIFF
--- a/src/main.jl
+++ b/src/main.jl
@@ -17,6 +17,7 @@ const DEFAULT_REGISTRIES = Pkg.RegistrySpec[Pkg.RegistrySpec(;
         include_jll::Bool=false,
         unsub_from_prs=false,
         cc_user=false,
+        short_branch_name=false,
     )
 
 Main entry point for the package.
@@ -35,6 +36,7 @@ Main entry point for the package.
 - `include_jll::Bool=false`: Include JLL packages to bump
 - `unsub_from_prs=false`: Unsubscribe the user from the pull requests
 - `cc_user=false`: CC the user on the pull requests
+- `short_branch_name=false`: Use a shorter branch name for created PRs
 """
 function main(
     env::AbstractDict=ENV,
@@ -49,6 +51,7 @@ function main(
     unsub_from_prs=false,
     cc_user=false,
     bump_version=false,
+    short_branch_name=false,
 )
     generated_prs = Vector{Union{GitHub.PullRequest,GitLab.MergeRequest}}()
 
@@ -80,6 +83,7 @@ function main(
                 unsub_from_prs=unsub_from_prs,
                 cc_user=cc_user,
                 bump_version=bump_version,
+                short_branch_name=false,
             )
 
             if !isnothing(pr)

--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -213,6 +213,7 @@ function make_pr_for_new_version(
     unsub_from_prs=false,
     cc_user=false,
     bump_version=false,
+    short_branch_name=false,
 )
     if !continue_with_pr(dep, bump_compat_containing_equality_specifier)
         return nothing
@@ -268,7 +269,7 @@ function make_pr_for_new_version(
             git_checkout(master_branch_name)
 
             # Create compathelper branch and check it out
-            new_branch_name = "compathelper/new_version/$(get_random_string())"
+            new_branch_name = get_new_branch_name(short_branch_name)
             git_branch(new_branch_name; checkout=true)
 
             # Add new compat entry to project.toml, bump the version if needed,
@@ -310,6 +311,15 @@ function make_pr_for_new_version(
     end
 
     return created_pr
+end
+
+function get_new_branch_name(short=false)
+    new_name = if short
+        "ch/$(get_random_string(; short=true))"
+    else
+        "compathelper/new_version/$(get_random_string())"
+    end
+    return new_name
 end
 
 function cc_mention_user(

--- a/src/utilities/utilities.jl
+++ b/src/utilities/utilities.jl
@@ -38,7 +38,11 @@ function add_compat_section!(project::Dict)
     return project
 end
 
-function get_random_string()
+function get_random_string(; short=false)
     randint = lpad(string(rand(UInt32)), 11, "0")
-    return string(utc_to_string(now_localzone()), "-", randint)
+    if short
+        return string(randint)
+    else
+        return string(utc_to_string(now_localzone()), "-", randint)
+    end
 end

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -341,6 +341,20 @@ end
     end
 end
 
+@testset "get_new_branch_name" begin
+    @testset "short" begin
+        nbn = CompatHelper.get_new_branch_name(true)
+        @test startswith(nbn, "ch/")
+        @test length(nbn) == 14
+    end
+
+    @testset "long" begin
+        nbn = CompatHelper.get_new_branch_name()
+        @test startswith(nbn, "compathelper/new_version/")
+        @test length(nbn) == 60
+    end
+end
+
 @testset "make_pr_for_new_version" begin
     @testset "latest_version === nothing" begin
         @test isnothing(

--- a/test/utilities/utilities.jl
+++ b/test/utilities/utilities.jl
@@ -34,7 +34,13 @@ end
 end
 
 @testset "get_random_string" begin
-    @test length(CompatHelper.get_random_string()) == 35
+    @testset "long" begin
+        @test length(CompatHelper.get_random_string()) == 35
+    end
+
+    @testset "short" begin
+        @test length(CompatHelper.get_random_string(; short=true)) == 11
+    end
 end
 
 @testset "add_compat_section!" begin


### PR DESCRIPTION
Hitting an issue where the branch names are too big for certain tests we are doing with AWS. This adds in a flag to use a shorter branch name. 