### PR TITLE
Bug-fix for bump_package_version! when Project version is undefined

### DIFF
--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -362,6 +362,9 @@ function modify_project_toml(
 end
 
 function bump_package_version!(project::Dict)
+    # do nothing if version is not defined
+    !("version" in keys(project)) && return nothing
+    
     version = VersionNumber(project["version"])
 
     # Only bump the version if prerelease is empty

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -284,6 +284,12 @@ end
         CompatHelper.bump_package_version!(mock_toml)
         @test mock_toml["version"] == "1.2.3-DEV"
     end
+    
+    @testset "version undefined" begin
+        mock_toml = Dict()
+        CompatHelper.bump_package_version!(mock_toml)
+        @test isempty(mock_toml)
+    end
 end
 
 @testset "cc_mention_user" begin


### PR DESCRIPTION
CompatHelper is in use for e.g. doc and test environments (additional dependencies) that do not define a version. This change ensures that CompatHelper won't error in that case.