### PR TITLE
In the recommended workflows for GitHub and GitLab, recommend that the General registry is installed via Git (instead of via the Pkg server)

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Add the General registry via Git"
-        run |
+        run: |
           import Pkg
           ENV["JULIA_PKG_SERVER"] = ""
           Pkg.Registry.add("General")

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -7,6 +7,11 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
+      - name: "Add the General registry via Git"
+        run |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
       - name: "Install CompatHelper"
         run: |
           import Pkg

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ CompatHelper:
     - |
       julia --color=yes -e "
         import Pkg;
+        ENV["JULIA_PKG_SERVER"] = "";
+        Pkg.Registry.add("General");
+    - |
+      julia --color=yes -e "
+        import Pkg;
         name = \"CompatHelper\";
         uuid = \"aa819f21-2bde-4658-8897-bab36330d9b7\";
         version = \"3\";

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ CompatHelper:
       julia --color=yes -e "
         import Pkg;
         ENV["JULIA_PKG_SERVER"] = "";
-        Pkg.Registry.add("General");
+        Pkg.Registry.add("General");"
     - |
       julia --color=yes -e "
         import Pkg;


### PR DESCRIPTION
This ensures that the latest version of CompatHelper is always used. For example, if we register a new release of CompatHelper that fixes a critical bug, the new release will be used immediately.