### PR TITLE
Recommend that most users use the new `compathelper-action` composite action

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -7,26 +7,6 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: "Add the General registry via Git"
-        run: |
-          import Pkg
-          ENV["JULIA_PKG_SERVER"] = ""
-          Pkg.Registry.add("General")
-        shell: julia --color=yes {0}
-      - name: "Install CompatHelper"
-        run: |
-          import Pkg
-          name = "CompatHelper"
-          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
-          version = "3"
-          Pkg.add(; name, uuid, version)
-        shell: julia --color=yes {0}
-      - name: "Run CompatHelper"
-        run: |
-          import CompatHelper
-          CompatHelper.main()
-        shell: julia --color=yes {0}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
+      - uses: JuliaRegistries/compathelper-action@v1
+        with:
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,18 +18,6 @@ Mocking.activate()
 
 Aqua.test_all(CompatHelper; ambiguities=false)
 
-@testset "`version =` line in the workflow file" begin
-    root_directory = dirname(dirname(@__FILE__))
-    project_file = joinpath(root_directory, "Project.toml")
-    version = Base.VersionNumber(TOML.parsefile(project_file)["version"])
-    major_version = version.major
-    @test major_version >= 1
-    workflow_dir = joinpath(root_directory, ".github", "workflows")
-    workflow_filename = joinpath(workflow_dir, "CompatHelper.yml")
-    workflow_filecontents = read(workflow_filename, String)
-    @test occursin(Regex("\\sversion = \"$(major_version)\"\n"), workflow_filecontents)
-    @test length(findall(r"version[\s]*?=", workflow_filecontents)) == 1
-end
 include("patches.jl")
 
 @testset "CompatHelper.jl" begin


### PR DESCRIPTION
This PR changes the officially recommended workflow file to use the new `compathelper-action` composite action: https://github.com/JuliaRegistries/compathelper-action

This PR should not be merged until we first tag a release of the `compathelper-action` action.