### PR TITLE
If the PR head repo is `nothing`, assume that this means that the PR was made from a fork, but the fork has been deleted

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
-version = "3.0.7"
+version = "3.0.8"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/pull_requests.jl
+++ b/src/pull_requests.jl
@@ -35,7 +35,16 @@ function get_pull_requests(
     return @mock unique(paginated_prs)
 end
 
-not_pr_fork(repo::GitHub.Repo, pr::GitHub.PullRequest) = !pr.head.repo.fork
+function not_pr_fork(repo::GitHub.Repo, pr::GitHub.PullRequest)
+    head_repo = pr.head.repo
+
+    # [TODO] [FIXME] figure out why this can sometimes be `nothing`
+    # For now, we'll assume that this means the PR was made from a fork, but that fork
+    # has been deleted.
+    head_repo === nothing && return false # "true" means "not a fork", so "false" means "yes a fork"
+
+    return !head_repo.fork
+end
 not_pr_fork(repo::GitLab.Project, pr::GitLab.MergeRequest) = repo.id == pr.project_id
 
 my_prs(username::String, pr::GitHub.PullRequest) = lower(pr.user.login) == lower(username)


### PR DESCRIPTION
Ref #391