### PR TITLE
Make GHA workflow reusable

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -7,6 +7,7 @@ on:
     secrets:
       DOCUMENTER_KEY:
         description: 'An SSH deploy key. See docs for more info.'
+        required: true
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   workflow_call:
     secrets:
-      COMPATHELPER_PRIV:
+      DOCUMENTER_KEY:
         description: 'An SSH deploy key. See docs for more info.'
 jobs:
   CompatHelper:

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+  workflow_call:
+    secrets:
+      DOCUMENTER_KEY:
+        description: 'An SSH deploy key. See docs for more info.'
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   workflow_call:
     secrets:
-      DOCUMENTER_KEY:
+      COMPATHELPER_PRIV:
         description: 'An SSH deploy key. See docs for more info.'
 jobs:
   CompatHelper:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ Create a file at `.github/workflows/CompatHelper.yml` with the contents of the [
 
 If you need to use any special arguments for the `main` function, you can modify this file to add them.
 
+You can also use a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows):
+
+```yaml
+name: CompatHelper
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 1 * * # First day of each month
+
+jobs:
+  compathelper:
+    uses: JuliaRegistries/CompatHelper.jl/.github/workflows/CompatHelper.yml@sm/reusable-workflow
+    secrets:
+      DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+```
+
 ### GitLab
 For GitLab you will want to add CompatHelper as a job in your `.gitlab-ci.yml` file such as:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ on:
 
 jobs:
   compathelper:
-    uses: JuliaRegistries/CompatHelper.jl/.github/workflows/CompatHelper.yml@sm/reusable-workflow
+    uses: JuliaRegistries/CompatHelper.jl/.github/workflows/CompatHelper.yml@master
     secrets:
       DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
 ```


### PR DESCRIPTION
This allows people to use the workflow without copying its entirety, similarly to calling an action.

More info: https://docs.github.com/en/actions/using-workflows/reusing-workflows

Test run: https://github.com/julia-actions/Example.jl/runs/5474751558?check_suite_focus=true (for a scheduled test run, you might have to check back in a few hours)

---

@DilumAluthge do you happen to have a way to test if it actually works when a dependency has to be bumped? Some kind of example package? That way the secrets could be tested properly