### PR TITLE
Allow `strict_version` entries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
-version = "3.1.0"
+version = "3.2.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/main.jl
+++ b/src/main.jl
@@ -57,6 +57,7 @@ function main(
     unsub_from_prs=false,
     cc_user=false,
     bump_version=false,
+    strict_version::Bool=false
 )
     generated_prs = Vector{Union{GitHub.PullRequest,GitLab.MergeRequest}}()
 
@@ -93,6 +94,7 @@ function main(
                 unsub_from_prs=unsub_from_prs,
                 cc_user=cc_user,
                 bump_version=bump_version,
+                strict_version=strict_version
             )
 
             if !isnothing(pr)

--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -28,7 +28,8 @@ function new_compat_entry(::EntryType, old_compat::Nothing, new_compat::Abstract
     return "$(strip(new_compat))"
 end
 
-function compat_version_number(ver::VersionNumber)
+function compat_version_number(ver::VersionNumber, strict_version::Bool=false)
+    strict_version && return "= $(ver.major).$(ver.minor).$(ver.patch)"
     (ver.major > 0) && return "$(ver.major)"
     (ver.minor > 0) && return "0.$(ver.minor)"
 
@@ -213,13 +214,14 @@ function make_pr_for_new_version(
     unsub_from_prs=false,
     cc_user=false,
     bump_version=false,
+    strict_version::Bool=false
 )
     if !continue_with_pr(dep, bump_compat_containing_equality_specifier)
         return nothing
     end
 
     # Get new compat entry version, pr title, and pr body text
-    compat_entry_for_latest_version = compat_version_number(dep.latest_version)
+    compat_entry_for_latest_version = compat_version_number(dep.latest_version, strict_version)
     brand_new_compat = new_compat_entry(
         entry_type, dep.version_verbatim, compat_entry_for_latest_version
     )

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -79,6 +79,19 @@ end
     @test CompatHelper.compat_version_number(vn) == expected
 end
 
+@testset "compat_version_number -- $(vn)" for (vn, expected) in [
+    (VersionNumber("1.0.0"), "= 1.0.0"),
+    (VersionNumber("1.1.1"), "= 1.1.1"),
+    (VersionNumber("1.1.0"), "= 1.1.0"),
+    (VersionNumber("0.1.0"), "= 0.1.0"),
+    (VersionNumber("0.1.1"), "= 0.1.1"),
+    (VersionNumber("0.0.1"), "= 0.0.1"),
+    (VersionNumber("0.0.0"), "= 0.0.0"),
+]
+    strict_version=true
+    @test CompatHelper.compat_version_number(vn, strict_version) == expected
+end
+#=
 @testset "subdir_string -- $(subdir)" for (subdir, expected) in [
     ("foobar", "foobar"), ("foo/bar", "bar"), ("1", "1"), ("", "")
 ]


### PR DESCRIPTION
- `strict_version` helps to restrict the version bumps to exact `"= major.minor.patch"` 
- This is useful when you depend on packages that don't always follow the semver and you want automated test+bump for each release
