### PR TITLE
Use an `Options` struct to pass options around, instead of needing to pass kwargs around everywhere

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
-version = "3.1.2"
+version = "3.2.0-DEV"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -4,9 +4,8 @@ function get_project_deps(
     api::Forge,
     ci::CIService,
     repo::Union{GitHub.Repo,GitLab.Project};
-    subdir::AbstractString="",
-    include_jll::Bool=false,
-    master_branch::Union{DefaultBranch,AbstractString}=DefaultBranch(),
+    options::Options,
+    subdir::AbstractString,
 )
     mktempdir() do f
         url_with_auth = get_url_with_auth(api, ci, repo)
@@ -14,13 +13,13 @@ function get_project_deps(
         @mock git_clone(url_with_auth, local_path)
 
         @mock cd(local_path) do
-            master_branch = @mock git_get_master_branch(master_branch)
+            master_branch = @mock git_get_master_branch(options.master_branch)
             @mock git_checkout(master_branch)
         end
 
         # Get all the compat dependencies from the local Project.toml file
         project_file = @mock joinpath(local_path, subdir, "Project.toml")
-        deps = get_project_deps(project_file; include_jll=include_jll)
+        deps = get_project_deps(project_file; include_jll=options.include_jll)
 
         return deps
     end

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,9 +1,3 @@
-const DEFAULT_REGISTRIES = Pkg.RegistrySpec[Pkg.RegistrySpec(;
-    name="General",
-    uuid="23338594-aafe-5451-b93e-139f81909106",
-    url="https://github.com/JuliaRegistries/General.git",
-)]
-
 """
     main(
         env::AbstractDict=ENV,
@@ -45,37 +39,27 @@ Main entry point for the package.
 function main(
     env::AbstractDict=ENV,
     ci_cfg::CIService=auto_detect_ci_service(; env=env);
-    entry_type::EntryType=KeepEntry(),
-    registries::Vector{Pkg.RegistrySpec}=DEFAULT_REGISTRIES,
-    use_existing_registries::Bool=false,
-    depot::String=DEPOT_PATH[1],
-    subdirs::AbstractVector{<:AbstractString}=[""],
-    master_branch::Union{DefaultBranch,AbstractString}=DefaultBranch(),
-    bump_compat_containing_equality_specifier=true,
-    pr_title_prefix::String="",
-    include_jll::Bool=false,
-    unsub_from_prs=false,
-    cc_user=false,
-    bump_version=false,
+    kwargs...,
 )
+    options = Options(; kwargs...)
+
     generated_prs = Vector{Union{GitHub.PullRequest,GitLab.MergeRequest}}()
 
     api, repo = get_api_and_repo(ci_cfg)
 
-    for subdir in subdirs
+    for subdir in options.subdirs
         deps = get_project_deps(
             api,
             ci_cfg,
             repo;
-            subdir=subdir,
-            include_jll=include_jll,
-            master_branch=master_branch,
+            options,
+            subdir,
         )
 
-        if use_existing_registries
-            get_existing_registries!(deps, depot)
+        if options.use_existing_registries
+            get_existing_registries!(deps, options.depot)
         else
-            get_latest_version_from_registries!(deps, registries)
+            get_latest_version_from_registries!(deps, options.registries)
         end
 
         for dep in deps
@@ -83,16 +67,10 @@ function main(
                 api,
                 repo,
                 dep,
-                entry_type,
+                options.entry_type,
                 ci_cfg;
-                subdir=subdir,
-                master_branch=master_branch,
-                env=env,
-                bump_compat_containing_equality_specifier=bump_compat_containing_equality_specifier,
-                pr_title_prefix=pr_title_prefix,
-                unsub_from_prs=unsub_from_prs,
-                cc_user=cc_user,
-                bump_version=bump_version,
+                options,
+                subdir,
             )
 
             if !isnothing(pr)

--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -205,16 +205,11 @@ function make_pr_for_new_version(
     dep::DepInfo,
     entry_type::EntryType,
     ci_cfg::CIService;
-    subdir::AbstractString="",
-    master_branch::Union{DefaultBranch,AbstractString}=DefaultBranch(),
-    env::AbstractDict=ENV,
-    bump_compat_containing_equality_specifier::Bool=true,
-    pr_title_prefix::String="",
-    unsub_from_prs=false,
-    cc_user=false,
-    bump_version=false,
+    env = ENV,
+    options::Options,
+    subdir::String,
 )
-    if !continue_with_pr(dep, bump_compat_containing_equality_specifier)
+    if !continue_with_pr(dep, options.bump_compat_containing_equality_specifier)
         return nothing
     end
 
@@ -231,7 +226,7 @@ function make_pr_for_new_version(
         subdir_string(subdir),
         body_info(entry_type, dep.package.name),
         title_parenthetical(entry_type),
-        pr_title_prefix,
+        options.pr_title_prefix,
     )
 
     # Make sure we haven't already created the same PR
@@ -264,7 +259,7 @@ function make_pr_for_new_version(
             cd(joinpath(tmpdir, LOCAL_REPO_NAME))
 
             # Checkout master branch
-            master_branch_name = git_get_master_branch(master_branch)
+            master_branch_name = git_get_master_branch(options.master_branch)
             git_checkout(master_branch_name)
 
             # Create compathelper branch and check it out
@@ -277,7 +272,7 @@ function make_pr_for_new_version(
                 dep.package.name,
                 joinpath(tmpdir, LOCAL_REPO_NAME, subdir),
                 brand_new_compat,
-                bump_version,
+                options.bump_version,
             )
             git_add()
 
@@ -301,8 +296,8 @@ function make_pr_for_new_version(
                     new_pr_body,
                 )
 
-                cc_user && cc_mention_user(forge, repo, new_pr; env=env)
-                unsub_from_prs && unsub_from_pr(forge, new_pr)
+                options.cc_user && cc_mention_user(forge, repo, new_pr; env=env)
+                options.unsub_from_prs && unsub_from_pr(forge, new_pr)
                 force_ci_trigger(
                     forge, new_pr_title, new_branch_name, pkey_filename; env=env
                 )

--- a/src/utilities/types.jl
+++ b/src/utilities/types.jl
@@ -35,3 +35,24 @@ function Base.in(p::Package, s::Set{DepInfo})
 
     return false
 end
+
+const DEFAULT_REGISTRIES = Pkg.RegistrySpec[Pkg.RegistrySpec(;
+    name="General",
+    uuid="23338594-aafe-5451-b93e-139f81909106",
+    url="https://github.com/JuliaRegistries/General.git",
+)]
+
+Base.@kwdef struct Options
+    entry_type::EntryType                              = KeepEntry()
+    registries::Vector{Pkg.RegistrySpec}               = DEFAULT_REGISTRIES
+    use_existing_registries::Bool                      = false
+    depot::String                                      = DEPOT_PATH[1]
+    subdirs::Vector{String}                            = [""]
+    master_branch::Union{DefaultBranch,AbstractString} = DefaultBranch()
+    bump_compat_containing_equality_specifier::Bool    = true
+    pr_title_prefix::String                            = ""
+    include_jll::Bool                                  = false
+    unsub_from_prs::Bool                               = false
+    cc_user::Bool                                      = false
+    bump_version::Bool                                 = false
+end

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -1,10 +1,14 @@
 @testset "get_project_deps" begin
     @testset "no jll" begin
         apply([git_clone_patch, project_toml_patch, cd_patch]) do
+            options = CompatHelper.Options()
+            subdir = options.subdirs |> only
             deps = CompatHelper.get_project_deps(
                 GitForge.GitHub.GitHubAPI(; token=GitHub.Token("token")),
                 GitHubActions(),
-                GitHub.Repo(; full_name="foobar"),
+                GitHub.Repo(; full_name="foobar");
+                options = options,
+                subdir = subdir,
             )
 
             @test length(deps) == 1
@@ -13,11 +17,16 @@
 
     @testset "include_jll" begin
         apply([git_clone_patch, project_toml_patch, cd_patch]) do
+            options = CompatHelper.Options(;
+                include_jll = true,
+            )
+            subdir = options.subdirs |> only
             deps = CompatHelper.get_project_deps(
                 GitForge.GitHub.GitHubAPI(; token=GitHub.Token("token")),
                 GitHubActions(),
                 GitHub.Repo(; full_name="foobar");
-                include_jll=true,
+                options = options,
+                subdir = subdir,
             )
 
             @test length(deps) == 2

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -423,19 +423,25 @@ end
 
 @testset "make_pr_for_new_version" begin
     @testset "latest_version === nothing" begin
+        options = CompatHelper.Options()
+        subdir = options.subdirs |> only
         @test isnothing(
             CompatHelper.make_pr_for_new_version(
                 GitHub.GitHubAPI(),
                 GitHub.Repo(),
                 CompatHelper.DepInfo(CompatHelper.Package("PackageA", UUID(1))),
                 CompatHelper.KeepEntry(),
-                CompatHelper.GitHubActions(),
+                CompatHelper.GitHubActions();
+                options,
+                subdir,
             ),
         )
     end
 
     @testset "pr_title exists" begin
         apply(pr_titles_mock) do
+            options = CompatHelper.Options()
+            subdir = options.subdirs |> only
             @test isnothing(
                 CompatHelper.make_pr_for_new_version(
                     GitHub.GitHubAPI(; token=GitHub.Token("token")),
@@ -446,7 +452,9 @@ end
                         version_verbatim="0.9",
                     ),
                     CompatHelper.KeepEntry(),
-                    CompatHelper.GitHubActions(),
+                    CompatHelper.GitHubActions();
+                    options,
+                    subdir,
                 ),
             )
         end
@@ -484,6 +492,8 @@ end
                         delete!(ENV, CompatHelper.PRIVATE_SSH_ENVVAR)
                     end
 
+                    options = CompatHelper.Options()
+                    subdir = options.subdirs |> only
                     pr = CompatHelper.make_pr_for_new_version(
                         GitHub.GitHubAPI(; token=GitHub.Token("token")),
                         GitHub.Repo(;
@@ -495,12 +505,16 @@ end
                             version_verbatim="1.2",
                         ),
                         CompatHelper.KeepEntry(),
-                        CompatHelper.GitHubActions(),
+                        CompatHelper.GitHubActions();
+                        options,
+                        subdir,
                     )
                     @test pr isa GitHub.PullRequest
 
                     # SSH
                     withenv(CompatHelper.PRIVATE_SSH_ENVVAR => "foo") do
+                        options = CompatHelper.Options()
+                        subdir = options.subdirs |> only
                         pr = CompatHelper.make_pr_for_new_version(
                             GitHub.GitHubAPI(; token=GitHub.Token("token")),
                             GitHub.Repo(;
@@ -512,7 +526,9 @@ end
                                 version_verbatim="2.1",
                             ),
                             CompatHelper.KeepEntry(),
-                            CompatHelper.GitHubActions(),
+                            CompatHelper.GitHubActions();
+                            options,
+                            subdir,
                         )
                         @test pr isa GitHub.PullRequest
                     end


### PR DESCRIPTION
Instead of needing to pass kwargs around everywhere, let's put all the kwargs into a single `Options` struct, and then we can just pass a single `options::Options` around, instead of needing to pass all of the kwargs around.