### PR TITLE
GitHub Actions: on self-hosted runners, we need to check if Julia is available in the `PATH`, and install it if needed

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,6 +10,16 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
+      - name: Check if Julia is already available in the PATH
+        id: julia_in_path
+        run: which julia
+        continue-on-error: true
+      - name: Install Julia, but only if it is not already available in the PATH
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+          arch: ${{ runner.arch }}
+        if: steps.julia_in_path.outcome != 'success'
       - name: "Add the General registry via Git"
         run: |
           import Pkg


### PR DESCRIPTION
1. On GitHub-hosted runners, we know that they will always have Julia pre-installed. Therefore, the `which julia` step will always succeed, and so we will never spend any time install Julia on GitHub-hosted runners.
2. On self-hosted runners, `which julia` will fail every time, so we will run the `setup-julia` action every time. However, this does not mean that we need to spend time installing Julia every time. The first time, the toolcache (e.g. `/runner/_work/_tool`) will be cold, so we will need to download and install Julia. But every subsequent time that we run the `setup-julia` action, the toolcache will be warm, and so running the `setup-julia` action will essentially be a no-op.