### PR TITLE
GitHub Actions: for now, comment out the `${{ runner.arch }}` line

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -18,7 +18,7 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-          arch: ${{ runner.arch }}
+          # arch: ${{ runner.arch }}
         if: steps.julia_in_path.outcome != 'success'
       - name: "Add the General registry via Git"
         run: |


### PR DESCRIPTION
We need https://github.com/julia-actions/setup-julia/pull/108 and https://github.com/julia-actions/setup-julia/pull/110 before we can uncomment this line.