### PR TITLE
GitHub Actions: uncomment the `${{ runner.arch }}` line

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -18,7 +18,7 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-          # arch: ${{ runner.arch }}
+          arch: ${{ runner.arch }}
         if: steps.julia_in_path.outcome != 'success'
       - name: "Add the General registry via Git"
         run: |


### PR DESCRIPTION
Follow-up to #430.

https://github.com/julia-actions/setup-julia/pull/108 and https://github.com/julia-actions/setup-julia/pull/110 have been merged and are available in a release, so we can now uncomment this line.