### PR TITLE
Pin Julia version

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,16 +10,11 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if Julia is already available in the PATH
-        id: julia_in_path
-        run: which julia
-        continue-on-error: true
-      - name: Install Julia, but only if it is not already available in the PATH
+      - name: Install Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: '1.8'
           arch: ${{ runner.arch }}
-        if: steps.julia_in_path.outcome != 'success'
       - name: "Add the General registry via Git"
         run: |
           import Pkg


### PR DESCRIPTION
CompatHelper v2 doesn't work on Julia 1.8. This causes all workflow runs that are pinned to CompatHelper v2 to fail since the runners are allowed to use any Julia version (see also #437). To solve this problem in the future, this PR proposes to explicitly install Julia v1.8.

@DilumAluthge 