### PR TITLE
Adds changes to fix GitForge compat bump

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
-version = "3.4.0"
+version = "3.5.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -16,7 +16,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-GitForge = "0.2.3"
+GitForge = "0.2.3, 0.4"
 Mocking = "0.7"
 MultilineStrings = "0.1"
 TimeZones = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-GitForge = "0.2.3, 0.3, 0.4"
+GitForge = "0.4"
 Mocking = "0.7"
 MultilineStrings = "0.1"
 TimeZones = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
-version = "3.4.0"
+version = "3.5.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -16,7 +16,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-GitForge = "0.2.3, 0.4"
+GitForge = "0.2.3, 0.3, 0.4"
 Mocking = "0.7"
 MultilineStrings = "0.1"
 TimeZones = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CompatHelper"
 uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
 authors = ["Dilum Aluthge", "Brown Center for Biomedical Informatics", "contributors"]
-version = "3.5.0"
+version = "3.4.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/patches.jl
+++ b/test/patches.jl
@@ -96,7 +96,7 @@ end
 gl_gpr_patch = @patch function CompatHelper.get_pull_requests(
     api::GitLab.GitLabAPI, repo::GitLab.Project, state::String
 )
-    origin_repo = GitLab.Project(; id=1, fork=false)
+    origin_repo = GitLab.Project(; id=1)
 
     pr_from_origin = GitLab.MergeRequest(;
         project_id=1, author=GitLab.User(; username="foobar"), title="title"

--- a/test/pull_requests.jl
+++ b/test/pull_requests.jl
@@ -61,8 +61,8 @@ end
         end
 
         @testset "GitLab" begin
-            origin_repo = GitLab.Project(; id=1, fork=false)
-            fork_repo = GitLab.Project(; id=2, fork=true)
+            origin_repo = GitLab.Project(; id=1)
+            fork_repo = GitLab.Project(; id=2)
 
             pr_from_origin = GitLab.MergeRequest(;
                 id=1, project_id=1, author=GitLab.User(; username=username), title="PR A"
@@ -110,7 +110,7 @@ end
         end
 
         @testset "GitLab" begin
-            origin_repo = GitLab.Project(; id=1, fork=false)
+            origin_repo = GitLab.Project(; id=1)
 
             pr_from_me = GitLab.MergeRequest(;
                 id=1, project_id=1, author=GitLab.User(; username=username), title="PR A"

--- a/test/utilities/new_versions.jl
+++ b/test/utilities/new_versions.jl
@@ -402,10 +402,14 @@ end
 
 @testset "unsub_from_pr" begin
     @testset "GitHub" begin
-        @test_throws ErrorException(
-            "GitForge.GitHub.GitHubAPI has not implemented this function"
+        api = GitHub.GitHubAPI()
+        @test_throws GitForge.ForgeAPINotImplemented(
+            GitForge.unsubscribe_from_pull_request,
+            (1, 1),
+            true,
+            api
         ) CompatHelper.unsub_from_pr(
-            GitHub.GitHubAPI(), GitHub.PullRequest(; repo=GitHub.Repo(; id=1), id=1)
+            api, GitHub.PullRequest(; repo=GitHub.Repo(; id=1), id=1)
         )
     end
 


### PR DESCRIPTION
Skipping 0.3 and going to 0.4 to ~~(hopefully)~~ fix the `datetime` changes between 0.3 and 0.4.1 found [here](https://github.com/JuliaRegistries/CompatHelper.jl/actions/runs/2862683110/jobs/4538934920#step:8:514).

Edit: After running `bors`, all the tests pass. Should be good to merge.