### PR TITLE
Fix Documenter to 0.27

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 CompatHelper = "aa819f21-2bde-4658-8897-bab36330d9b7"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "0.27.0"


### PR DESCRIPTION
This project is not compatible with Documenter 1.0 yet. So we should pin it to 0.27 for now, so that building the docs still succeeds. 