### PR TITLE
Check `docs/Project.toml` and `test/Project.toml` as well

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ Modules = [CompatHelper]
 
 # [CompatHelper.jl](https://github.com/JuliaRegistries/CompatHelper.jl)
 
-CompatHelper is a Julia package that helps you keep your `[compat]` entries up-to-date.
+CompatHelper is a Julia package that helps you keep your `[compat]` entries up-to-date in your `Project.toml`, `docs/Project.toml`, and `test/Project.toml` (if they exist).
 Whenever one of your package's dependencies releases a new breaking version, CompatHelper opens a pull request on your repository that modifies your `[compat]` entry to reflect the newly released version.
 We would like to eventually add Julia support to [Dependabot](https://dependabot.com).
 If you would like to help with adding Julia support to Dependabot, join us in the `#dependabot` channel on the [Julia Language Slack](https://julialang.org/slack/).

--- a/src/main.jl
+++ b/src/main.jl
@@ -35,7 +35,8 @@ Main entry point for the package.
 - `include_jll::Bool=false`: Include JLL packages to bump
 - `unsub_from_prs=false`: Unsubscribe the user from the pull requests
 - `cc_user=false`: CC the user on the pull requests
-- `bump_version=false`: When set to true, the version in Project.toml will be bumped if a pull request is made. Minor bump if >= 1.0, or patch bump if < 1.0
+- `bump_version=false`: When set to true, the version in Project.toml will be bumped if a pull request to the main Project.toml of the package is made.
+  Minor bump if >= 1.0, or patch bump if < 1.0
 - `include_yanked=false`: When set to true, yanked versions will be included when calculating what the latest version of a package is
 """
 function main(

--- a/src/utilities/new_versions.jl
+++ b/src/utilities/new_versions.jl
@@ -209,8 +209,14 @@ function make_pr_for_new_version(
     options::Options,
     subdir::String,
     local_clone_path::AbstractString,
+    is_main_project::Bool=true
 )
     if !continue_with_pr(dep, options.bump_compat_containing_equality_specifier)
+        return nothing
+    end
+
+    # Don't create new compat entries in docs/ and test/, only update existing ones
+    if isnothing(dep.version_verbatim) && !is_main_project
         return nothing
     end
 
@@ -268,7 +274,7 @@ function make_pr_for_new_version(
             dep.package.name,
             joinpath(local_clone_path, subdir),
             brand_new_compat,
-            options.bump_version,
+            options.bump_version && is_main_project,
         )
         git_add()
 


### PR DESCRIPTION
Resolves https://github.com/JuliaRegistries/CompatHelper.jl/issues/408.

I made some decisions while adding this, that could be converted into config settings at a later point, if so desired:

1. Do not create new compat entries here, only update existing ones. Many projects duplicate some of their deps as test-deps as well, but do not want to keep track of both compats, as the test-dep compat is clear due to transitivity anyway.
2. Updating a compat entry here does never do a version bump in the main Project.toml. But I think this is fine as one does not need to release a change to test-deps or docs-deps anyway.

Unfortunately, I do not see myself being able to write tests for this. I am just lost in the mocking and patching.