### PR TITLE
GitHub: get API url and server URL from env

### DIFF
--- a/src/utilities/ci.jl
+++ b/src/utilities/ci.jl
@@ -62,7 +62,10 @@ end
 
 function auto_detect_ci_service(; env::AbstractDict=ENV)
     if haskey(env, "GITHUB_REPOSITORY")
-        return GitHubActions()
+        api_hostname = get(env, "GITHUB_API_URL", "https://api.github.com")
+        clone_hostname = get(env, "GITHUB_SERVER_URL", "github.com")
+        clone_hostname = replace(clone_hostname, r"^(https?://)?" => "")
+        return GitHubActions(; api_hostname, clone_hostname)
     elseif haskey(env, "GITLAB_CI")
         return GitLabCI()
     else


### PR DESCRIPTION
I encountered difficulties trying to use CompatHelper.jl on an Enterprise server, but it turns out I just needed to set the API url and the hostname correctly.

This pull request updates `auto_detect_ci_service` to automatically handle non-GitHub.com GitHub servers.

I am not sure how to add tests for this.

@DilumAluthge I see you are probably the most active here. Can you take a look at this and advise on tests?