### PR TITLE
Consider the extras block when checking for new versions

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -21,7 +21,7 @@ function get_project_deps(project_file::AbstractString; include_jll::Bool=false)
     dep_section = Dict{DepInfo,String}()
     project = TOML.parsefile(project_file)
 
-    for section in ["deps", "weakdeps"]
+    for section in ["deps", "weakdeps", "extras"]
         if haskey(project, section)
             deps = project[section]
             add_compat_section!(project)

--- a/test/dependencies.jl
+++ b/test/dependencies.jl
@@ -20,6 +20,8 @@ end
     for (k, s) in pairs(dep_section)
         if k.package.name ∈ ["Bex_jll", "Skix"]
             @test s == "weakdeps"
+        elseif k.package.name ∈ ["Baz"]
+            @test s == "extras"
         else
             @test s == "deps"
         end
@@ -31,6 +33,8 @@ end
     for (k, s) in pairs(dep_section)
         if k.package.name == "Skix"
             @test s == "weakdeps"
+        elseif k.package.name == "Baz"
+            @test s == "extras"
         else
             @test s == "deps"
         end
@@ -142,7 +146,7 @@ end
     project_file = joinpath(pkgdir(CompatHelper), "Project.toml")
 
     # Just for this test, we hardcode this list
-    unregistered_stdlibs = ["Base64", "Dates", "Pkg", "UUIDs"]
+    unregistered_stdlibs = ["Base64", "Dates", "Pkg", "Random", "Test", "UUIDs"]
 
     @test ispath(project_file)
     @test isfile(project_file)

--- a/test/deps/Project.toml
+++ b/test/deps/Project.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 
 [deps]
 Foobar_jll = "6ca821de-e512-569d-89d9-0b16ce691416"
-Baz = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [weakdeps]
@@ -13,6 +12,9 @@ Skix = "3db6da90-6ed3-11ee-0779-f549c8e3e90d"
 
 [extensions]
 Ext = ["Bex_jll", "Skix"]
+
+[extras]
+Baz = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
 Foobar_jll = "1"


### PR DESCRIPTION
With the work in https://github.com/JuliaRegistries/CompatHelper.jl/pull/458, it seems like it's pretty simple to close #166 as also conjectured in that issue.