### PR TITLE
Tests: re-enable GitLab integration tests

### DIFF
--- a/test/integration_tests.jl
+++ b/test/integration_tests.jl
@@ -276,7 +276,7 @@ end
 
 const services_to_test = [
     GITHUB,
-    # GITLAB,
+    GITLAB,
 ]
 @testset "$(service)" for service in services_to_test
     personal_access_token = ENV["INTEGRATION_PAT_$(service)"]


### PR DESCRIPTION
Follow-up to #509.

We'll have to figure out how to get a new GitLab token.