### PR TITLE
Update GitHub action workflows

### DIFF
--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -29,16 +29,7 @@ jobs:
         with:
           version: '1'
           arch: x64
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - run: git config --global user.email "noreply@example.com"
       - run: git config --global user.name "GitHub Actions"

--- a/.github/workflows/ci_integration.yml
+++ b/.github/workflows/ci_integration.yml
@@ -45,7 +45,7 @@ jobs:
           INTEGRATION_PAT_GITLAB: ${{ secrets.INTEGRATION_PAT_GITLAB }}
           INTEGRATION_REPO_SSH_KEY_GITLAB: ${{ secrets.INTEGRATION_REPO_SSH_KEY_GITLAB }}
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -29,16 +29,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -35,9 +35,9 @@ jobs:
         env:
           COMPATHELPER_RUN_INTEGRATION_TESTS: "false"
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
   documentation:
     name: Documentation

--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -47,14 +47,8 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
-        env:
-          JULIA_PKG_SERVER: ''
-      - run: julia --project=docs docs/make.jl
+      - uses: julia-actions/cache@v2
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
@@ -66,16 +60,18 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
+      - name: Instantiate environment
+        shell: julia --color=yes --project=docs {0}
+        run: |
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
         env:
           JULIA_PKG_SERVER: ''
-      - run: |
-          julia --project=docs -e '
-            using Documenter: DocMeta, doctest
-            using CompatHelper
-            DocMeta.setdocmeta!(CompatHelper, :DocTestSetup, :(using CompatHelper); recursive=true)
-            doctest(CompatHelper)'
+      - name: Run doctests
+        shell: julia --color=yes --project=docs {0}
+        run: |
+          using Documenter: DocMeta, doctest
+          using CompatHelper
+          DocMeta.setdocmeta!(CompatHelper, :DocTestSetup, :(using CompatHelper); recursive=true)
+          doctest(CompatHelper)

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -10,11 +10,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install the JuliaFormatter package
-        run: julia --color=yes -e 'using Pkg; Pkg.add(name = "JuliaFormatter", uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899")'
+        shell: julia --color=yes {0}
+        run: using Pkg; Pkg.add(name = "JuliaFormatter", uuid = "98e50ef6-434e-11e9-1051-2b60c6c9e899")
       - name: Precompile dependencies
-        run: julia --color=yes -e 'using Pkg; Pkg.precompile()'
+        shell: julia --color=yes {0}
+        run: using Pkg; Pkg.precompile()
       - name: Use JuliaFormatter to format the code with the BlueStyle style
-        run: julia --color=yes -e 'using JuliaFormatter; format(".", BlueStyle(); verbose = true)'
+        shell: julia --color=yes {0}
+        run: using JuliaFormatter; format(".", BlueStyle(); verbose = true)
       - name: Create pull request
         id: create_pr
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5


### PR DESCRIPTION
- Use julia-actions/cache instead of actions/cache for less boilerplate
- Use julia-actions/docdeploy instead of manually specifying julia commands
- Use `shell:` option for cleaner job step specifications
- Update codecov/codecov-action to use newest version (v5)
  - Update options for codecov-action